### PR TITLE
refine: rewrite trust pages and onboarding copy

### DIFF
--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, Suspense } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { AppShell } from "@/components/app-shell";
 import { createClient } from "@/utils/supabase/client";
@@ -10,7 +10,7 @@ function OnboardingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const supabase = createClient();
-  
+
   const [displayName, setDisplayName] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -19,10 +19,10 @@ function OnboardingContent() {
   const isInviteFlow = nextPath?.includes("/share/");
 
   const eyebrow = isInviteFlow ? "Almost there" : "Welcome";
-  const title = "Setting up your workspace.";
-  const description = isInviteFlow 
-    ? "Before you view the shared summary, enter your name. Your work stays private until you choose to share it back."
-    : "This helps us personalize how you usually respond under pressure and what helps you feel steady.";
+  const title = "Finish setting up your account.";
+  const description = isInviteFlow
+    ? "Before you open the shared summary, add your name so we can finish your setup."
+    : "Add your name to continue to your workspace.";
 
   return (
     <AppShell
@@ -31,13 +31,13 @@ function OnboardingContent() {
       description={description}
       accent="#22d3ee"
     >
-      <div style={{ maxWidth: 640, marginTop: 48 }}>
-        <div style={{ display: "grid", gap: 32 }}>
+      <div style={{ maxWidth: 640, marginTop: 32 }}>
+        <div style={{ display: "grid", gap: 28 }}>
           <div style={{ display: "grid", gap: 12 }}>
             <label style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.4)" }}>
               Your full name
             </label>
-            <div style={{ display: "flex", alignItems: "center", gap: 16, borderRadius: 20, border: "1px solid rgba(255, 255, 255, 0.1)", background: "rgba(0,0,0,0.2)", padding: "18px 24px" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 14, borderRadius: 16, border: "1px solid rgba(255, 255, 255, 0.1)", background: "rgba(0,0,0,0.2)", padding: "16px 20px" }}>
               <User style={{ width: 18, height: 18, color: "rgba(245, 245, 245, 0.4)" }} />
               <input
                 value={displayName}
@@ -49,52 +49,54 @@ function OnboardingContent() {
                   border: "none",
                   background: "transparent",
                   color: "white",
-                  fontSize: 18,
+                  fontSize: 17,
                   outline: "none",
-                  fontWeight: 400
+                  fontWeight: 400,
                 }}
               />
             </div>
           </div>
 
-          <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
             <button
               type="button"
               onClick={async () => {
-                 setBusy(true);
-                 setError(null);
-                 try {
-                    const { data: { user } } = await supabase.auth.getUser();
+                setBusy(true);
+                setError(null);
+                try {
+                  const {
+                    data: { user },
+                  } = await supabase.auth.getUser();
 
-                    if (!user) {
-                      router.push("/login");
-                      return;
-                    }
+                  if (!user) {
+                    router.push("/login");
+                    return;
+                  }
 
-                    const metadata = {
-                      ...user.user_metadata,
-                      display_name: displayName.trim() || user.user_metadata?.display_name,
-                      onboarding_completed: true,
-                    };
+                  const metadata = {
+                    ...user.user_metadata,
+                    display_name: displayName.trim() || user.user_metadata?.display_name,
+                    onboarding_completed: true,
+                  };
 
-                    const updateResult = await supabase.auth.updateUser({ data: metadata });
-                    if (updateResult.error) {
-                      throw updateResult.error;
-                    }
+                  const updateResult = await supabase.auth.updateUser({ data: metadata });
+                  if (updateResult.error) {
+                    throw updateResult.error;
+                  }
 
-                    router.push(nextPath && nextPath.startsWith("/") ? nextPath : "/dynamics");
-                    router.refresh();
-                 } catch (err) {
-                    setError(err instanceof Error ? err.message : "Unable to complete setup");
-                 } finally {
-                    setBusy(false);
-                 }
+                  router.push(nextPath && nextPath.startsWith("/") ? nextPath : "/dynamics");
+                  router.refresh();
+                } catch (err) {
+                  setError(err instanceof Error ? err.message : "Unable to complete setup");
+                } finally {
+                  setBusy(false);
+                }
               }}
               disabled={busy || !displayName.trim()}
               style={{
                 width: "fit-content",
-                padding: "20px 48px",
-                borderRadius: 9999,
+                padding: "16px 28px",
+                borderRadius: 14,
                 border: 0,
                 background: "white",
                 color: "#050505",
@@ -104,22 +106,20 @@ function OnboardingContent() {
                 opacity: busy || !displayName.trim() ? 0.6 : 1,
                 display: "flex",
                 alignItems: "center",
-                gap: 12,
-                transition: "all 0.2s ease",
-                boxShadow: "0 20px 40px rgba(0,0,0,0.4)"
+                gap: 10,
               }}
             >
-              {busy ? "Saving..." : isInviteFlow ? "View summary" : "Continue to DEFRAG"}
+              {busy ? "Saving..." : isInviteFlow ? "Open summary" : "Continue to workspace"}
               {!busy && <ArrowRight style={{ width: 18, height: 18 }} />}
             </button>
 
-            <p style={{ margin: 0, fontSize: 13, color: "rgba(245, 245, 245, 0.4)", lineHeight: 1.6, maxWidth: 400 }}>
-              Your workspace is local to your device and is never used for training models or shared without your permission.
+            <p style={{ margin: 0, fontSize: 13, color: "rgba(245, 245, 245, 0.44)", lineHeight: 1.6, maxWidth: 440 }}>
+              Your account helps keep your workspace available when you come back. You stay in control of what you keep and share.
             </p>
           </div>
 
           {error ? (
-            <div style={{ padding: 16, borderRadius: 16, background: "rgba(220, 38, 38, 0.1)", border: "1px solid rgba(220, 38, 38, 0.2)", color: "#fca5a5", fontSize: 13 }}>
+            <div style={{ padding: 14, borderRadius: 14, background: "rgba(220, 38, 38, 0.1)", border: "1px solid rgba(220, 38, 38, 0.2)", color: "#fca5a5", fontSize: 13 }}>
               {error}
             </div>
           ) : null}
@@ -131,7 +131,7 @@ function OnboardingContent() {
 
 export default function OnboardingPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<div style={{ minHeight: "100vh", background: "#050505" }} />}>
       <OnboardingContent />
     </Suspense>
   );

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -2,20 +2,20 @@ import { AppShell } from "../../components/app-shell";
 
 const sections = [
   {
-    title: "Data used for the service",
-    body: "DEFRAG uses account information, subscription state, and the guidance inputs you provide in order to deliver the website product and any connected MCP or ChatGPT service flows.",
+    title: "What we collect",
+    body: "Defrag uses the information you provide, your account details, and your plan status to keep your workspace running and deliver the product experience.",
   },
   {
-    title: "Canonical account owner",
-    body: "defrag.app is the canonical owner of your account relationship. Integration surfaces may receive scoped access through DEFRAG-owned auth flows, but account state and billing remain on the main site.",
+    title: "How we use it",
+    body: "We use your information to support sign-in, save your workspace, deliver insights, and keep your account working as expected.",
   },
   {
-    title: "Billing and payment data",
-    body: "Checkout and billing portal flows are routed through DEFRAG-owned billing surfaces. Payment processing is handled through Stripe-backed flows on the canonical website.",
+    title: "Billing",
+    body: "Payments and subscription changes are handled through Defrag and our payment provider. Billing details are used only to process and manage your plan.",
   },
   {
-    title: "Security and access",
-    body: "Access to protected DEFRAG capabilities is controlled through DEFRAG-owned authentication, signed tokens where applicable, and plan-based entitlement checks tied to canonical account state.",
+    title: "Security and control",
+    body: "We use authentication, access controls, and plan checks to protect your account. You control what you choose to keep, use, and share.",
   },
 ];
 
@@ -23,18 +23,18 @@ export default function PrivacyPage() {
   return (
     <AppShell
       eyebrow="Privacy"
-      title="Privacy stays attached to the canonical DEFRAG account."
-      description="The website on defrag.app remains the trust and policy surface for account access, billing, and integration-linked usage."
+      title="Privacy should be clear and easy to understand."
+      description="This page explains what Defrag uses, why it uses it, and how your account stays protected."
       accent="#22d3ee"
     >
-      <div style={{ maxWidth: 720, display: "grid", gap: 64 }}>
+      <div style={{ maxWidth: 760, display: "grid", gap: 48 }}>
         {sections.map((section, i) => (
-          <div key={section.title} style={{ display: "grid", gap: 16 }}>
-            <div style={{ display: "flex", alignItems: "baseline", gap: 16 }}>
+          <div key={section.title} style={{ display: "grid", gap: 14 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 14, flexWrap: "wrap" }}>
               <span style={{ fontSize: 12, color: "rgba(245,245,245,0.3)", fontWeight: 500 }}>{String(i + 1).padStart(2, "0")}</span>
               <h2 style={{ margin: 0, fontSize: 22, fontWeight: 500, color: "white" }}>{section.title}</h2>
             </div>
-            <p style={{ margin: 0, paddingLeft: 36, color: "rgba(245,245,245,0.65)", lineHeight: 1.8, fontSize: 16, fontWeight: 300 }}>
+            <p style={{ margin: 0, paddingLeft: 32, color: "rgba(245,245,245,0.65)", lineHeight: 1.8, fontSize: 16, fontWeight: 300 }}>
               {section.body}
             </p>
           </div>

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -2,20 +2,20 @@ import { AppShell } from "../../components/app-shell";
 
 const sections = [
   {
-    title: "Use of the service",
-    body: "DEFRAG provides interpretive guidance and account-linked product features. It is not emergency support, legal advice, medical advice, or a substitute for licensed clinical care.",
+    title: "Using Defrag",
+    body: "Defrag helps you think through difficult interactions more clearly. It is not emergency support, legal advice, medical advice, or a substitute for licensed care.",
   },
   {
-    title: "Accounts and access",
-    body: "Your DEFRAG account is the canonical access point for website and integration-linked usage. You are responsible for maintaining the security of your sign-in credentials and any linked sessions.",
+    title: "Accounts",
+    body: "You are responsible for keeping your sign-in method secure and for using your account in a lawful and respectful way.",
   },
   {
-    title: "Subscriptions and billing",
-    body: "All subscription, checkout, upgrade, and billing-portal actions are owned by DEFRAG on defrag.app. Third-party integration surfaces may initiate redirects, but they do not become billing owners.",
+    title: "Plans and billing",
+    body: "If you choose a paid plan, billing and subscription changes are handled through Defrag and our payment provider.",
   },
   {
     title: "Acceptable use",
-    body: "You may not misuse the product, attempt to bypass authentication or entitlements, interfere with service operation, or use DEFRAG in ways that violate applicable law or the rights of others.",
+    body: "You may not misuse the product, interfere with the service, try to bypass access controls, or use Defrag in a way that harms others or breaks the law.",
   },
 ];
 
@@ -23,18 +23,18 @@ export default function TermsPage() {
   return (
     <AppShell
       eyebrow="Terms"
-      title="Terms that keep ownership and responsibility clear."
-      description="The public website remains the owner of account, billing, and legal responsibility. Integration surfaces extend DEFRAG but do not replace the canonical product relationship."
+      title="Terms should be straightforward."
+      description="These terms explain the basic rules for using Defrag, keeping your account secure, and managing paid access."
       accent="rgba(245, 245, 245, 0.5)"
     >
-      <div style={{ maxWidth: 720, display: "grid", gap: 64 }}>
+      <div style={{ maxWidth: 760, display: "grid", gap: 48 }}>
         {sections.map((section, i) => (
-          <div key={section.title} style={{ display: "grid", gap: 16 }}>
-            <div style={{ display: "flex", alignItems: "baseline", gap: 16 }}>
+          <div key={section.title} style={{ display: "grid", gap: 14 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 14, flexWrap: "wrap" }}>
               <span style={{ fontSize: 12, color: "rgba(245,245,245,0.3)", fontWeight: 500 }}>{String(i + 1).padStart(2, "0")}</span>
               <h2 style={{ margin: 0, fontSize: 22, fontWeight: 500, color: "white" }}>{section.title}</h2>
             </div>
-            <p style={{ margin: 0, paddingLeft: 36, color: "rgba(245,245,245,0.65)", lineHeight: 1.8, fontSize: 16, fontWeight: 300 }}>
+            <p style={{ margin: 0, paddingLeft: 32, color: "rgba(245,245,245,0.65)", lineHeight: 1.8, fontSize: 16, fontWeight: 300 }}>
               {section.body}
             </p>
           </div>


### PR DESCRIPTION
This rewrites privacy, terms, and onboarding into simpler public-facing language. It removes internal product terminology, makes onboarding easier to understand, and keeps the pages aligned with the broader Defrag voice and mobile-friendly spacing.