### PR TITLE
refine: clean navigation and reframe plans language

### DIFF
--- a/apps/web/src/app/account/billing/page.tsx
+++ b/apps/web/src/app/account/billing/page.tsx
@@ -15,8 +15,8 @@ export default async function BillingPage() {
         title="Choose the level of access that fits how you want to use Defrag."
         description="Start with the workspace you need today. You can change your plan later."
       >
-        <div style={{ maxWidth: 880, display: "grid", gap: 48 }}>
-          <div style={{ display: "grid", gap: 16, maxWidth: 640 }}>
+        <div style={{ maxWidth: 920, display: "grid", gap: 48 }}>
+          <div style={{ display: "grid", gap: 16, maxWidth: 680 }}>
             <h3 style={{ margin: 0, fontSize: 22, fontWeight: 500, color: "white" }}>Sign in to choose a plan</h3>
             <p style={{ margin: 0, fontSize: 16, color: "rgba(245,245,245,0.64)", lineHeight: 1.7, fontWeight: 300 }}>
               Your account keeps your workspace, insights, and plan in one place. Sign in to continue.
@@ -49,8 +49,8 @@ export default async function BillingPage() {
             <div style={{ fontSize: 30, fontWeight: 400, color: "white", letterSpacing: "-0.02em", display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
               {activePlanKey === "realtime" ? "Studio+" : activePlanKey === "studio" ? "Studio" : activePlanKey === "core" ? "Core" : "Base"}
               {isSubscribed ? (
-                <span style={{ padding: "4px 10px", borderRadius: 9999, background: "rgba(16,185,129,0.1)", border: "1px solid rgba(16,185,129,0.2)", color: "#6ee7b7", fontSize: 10, fontWeight: 600, letterSpacing: "0.14em", textTransform: "uppercase" }}>
-                  Active
+                <span style={{ padding: "4px 10px", border: "1px solid rgba(16,185,129,0.2)", color: "#6ee7b7", fontSize: 10, fontWeight: 600, letterSpacing: "0.14em", textTransform: "uppercase" }}>
+                  Current
                 </span>
               ) : null}
             </div>
@@ -70,34 +70,34 @@ function PlanBreakdown({ activePlanKey }: { activePlanKey: string | null }) {
   const plans = [
     {
       key: "base",
-      label: "Base",
+      label: "Free",
       price: "Included",
-      description: "A simple starting point for saving context and opening your workspace.",
+      description: "An introduction to relational awareness and access to your workspace.",
     },
     {
       key: "core",
-      label: "Core",
+      label: "Solo",
       price: "$15",
       period: "/ month",
-      description: "Ongoing insight access for people who want regular support reading difficult interactions.",
+      description: "Full personal relational intelligence for people who want regular support understanding difficult interactions.",
     },
     {
       key: "studio",
-      label: "Studio",
+      label: "Team",
       price: "$45",
       period: "/ month",
-      description: "Deeper pattern review for people who want a broader view across time, timing, and repeated tension.",
+      description: "Relational intelligence across collaborative systems, recurring pressure, and broader dynamics across time.",
     },
   ];
 
   return (
     <div style={{ display: "grid", gap: 28 }}>
-      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: "rgba(245,245,245,0.4)" }}>Plans</div>
+      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: "rgba(245,245,245,0.4)" }}>Access tiers</div>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 28 }} className="plans-grid">
         {plans.map((plan) => {
-          const isActive = activePlanKey === plan.key;
+          const isActive = activePlanKey === plan.key || (!activePlanKey && plan.key === "base");
           return (
-            <div key={plan.key} style={{ display: "grid", gap: 14, padding: 24, border: "1px solid rgba(255,255,255,0.08)", background: isActive ? "rgba(255,255,255,0.05)" : "rgba(255,255,255,0.02)" }}>
+            <div key={plan.key} style={{ display: "grid", gap: 14, padding: 24, borderLeft: isActive ? "2px solid rgba(255,255,255,0.8)" : "1px solid rgba(255,255,255,0.08)", background: isActive ? "rgba(255,255,255,0.04)" : "rgba(255,255,255,0.02)" }}>
               <div style={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.14em", color: isActive ? "#ffffff" : "rgba(245,245,245,0.56)" }}>
                 {plan.label}
               </div>
@@ -108,7 +108,7 @@ function PlanBreakdown({ activePlanKey }: { activePlanKey: string | null }) {
               <p style={{ margin: 0, color: "rgba(245,245,245,0.64)", lineHeight: 1.7, fontSize: 14, fontWeight: 300 }}>
                 {plan.description}
               </p>
-              {isActive ? <div style={{ fontSize: 12, color: "rgba(255,255,255,0.56)" }}>Current plan</div> : null}
+              {isActive ? <div style={{ fontSize: 12, color: "rgba(255,255,255,0.56)" }}>Current access</div> : null}
             </div>
           );
         })}

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -13,22 +13,28 @@ interface AppShellProps {
   hideHero?: boolean;
 }
 
-export function AppShell({ 
-  eyebrow, title, description, children, accent = "#22d3ee", hideHero = false 
+export function AppShell({
+  eyebrow,
+  title,
+  description,
+  children,
+  accent = "#22d3ee",
+  hideHero = false,
 }: AppShellProps) {
   const pathname = usePathname();
   const navItems = [
     { href: "/", label: "Home", match: (value: string) => value === "/" },
-    { href: "/dynamics", label: "Product", match: (value: string) => value.startsWith("/dynamics") },
-    { href: "/about", label: "Method", match: (value: string) => value.startsWith("/about") },
-    { href: "/account/billing", label: "Pricing", match: (value: string) => value.startsWith("/account/billing") || value.startsWith("/pricing") },
+    { href: "/about", label: "How it works", match: (value: string) => value.startsWith("/about") },
+    { href: "/account/billing", label: "Plans", match: (value: string) => value.startsWith("/account/billing") || value.startsWith("/pricing") },
+    { href: "/login", label: "Sign in", match: (value: string) => value.startsWith("/login") },
   ];
+
   const footerItems = [
-    { href: "/about", label: "About" },
-    { href: "/account/billing", label: "Pricing" },
+    { href: "/about", label: "How it works" },
+    { href: "/account/billing", label: "Plans" },
     { href: "/terms", label: "Terms" },
     { href: "/privacy", label: "Privacy" },
-    { href: "/login", label: "Sign In" },
+    { href: "/login", label: "Sign in" },
   ];
 
   return (
@@ -37,8 +43,9 @@ export function AppShell({
         minHeight: "100vh",
         color: "#f5f5f5",
         backgroundColor: "#050505",
-        backgroundImage: "radial-gradient(circle at 0% 0%, rgba(34, 211, 238, 0.04), transparent 30%), radial-gradient(circle at 100% 0%, rgba(79, 70, 229, 0.03), transparent 30%)",
-        backgroundAttachment: "fixed"
+        backgroundImage:
+          "radial-gradient(circle at 0% 0%, rgba(34, 211, 238, 0.04), transparent 30%), radial-gradient(circle at 100% 0%, rgba(79, 70, 229, 0.03), transparent 30%)",
+        backgroundAttachment: "fixed",
       }}
     >
       <div
@@ -57,13 +64,24 @@ export function AppShell({
             justifyContent: "space-between",
             alignItems: "center",
             paddingBottom: 0,
+            gap: 24,
           }}
         >
           <div style={{ display: "flex", alignItems: "center", gap: 32 }}>
-            <Link href="/" style={{ textDecoration: "none", color: "white", fontSize: 16, fontWeight: 600, letterSpacing: "0.2em", textTransform: "uppercase" }}>
+            <Link
+              href="/"
+              style={{
+                textDecoration: "none",
+                color: "white",
+                fontSize: 16,
+                fontWeight: 600,
+                letterSpacing: "0.2em",
+                textTransform: "uppercase",
+              }}
+            >
               DEFRAG
             </Link>
-            
+
             <nav style={{ display: "flex", gap: 24 }} className="desktop-nav">
               {navItems.map((item) => {
                 const active = item.match(pathname);
@@ -76,7 +94,7 @@ export function AppShell({
                       fontSize: 13,
                       fontWeight: 500,
                       color: active ? "white" : "rgba(245, 245, 245, 0.45)",
-                      transition: "color 0.2s ease"
+                      transition: "color 0.2s ease",
                     }}
                   >
                     {item.label}
@@ -86,60 +104,103 @@ export function AppShell({
             </nav>
           </div>
 
-          <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-             <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 12px", borderRadius: 99, border: "1px solid rgba(255,255,255,0.08)", background: "rgba(255,255,255,0.03)", fontSize: 11, color: "rgba(245,245,245,0.5)" }}>
-                <div style={{ width: 6, height: 6, borderRadius: "50%", background: "#22d3ee" }} />
-                Active
-             </div>
-             <Link href="/login" style={{ fontSize: 13, fontWeight: 500, color: "white", textDecoration: "none", padding: "8px 16px", borderRadius: 12, border: "1px solid rgba(255,255,255,0.1)", background: "rgba(245,245,245,0.05)" }}>
-               Sign in
-             </Link>
-          </div>
+          <Link
+            href="/login"
+            style={{
+              fontSize: 13,
+              fontWeight: 500,
+              color: "white",
+              textDecoration: "none",
+              padding: "8px 16px",
+              borderRadius: 12,
+              border: "1px solid rgba(255,255,255,0.1)",
+              background: "rgba(245,245,245,0.05)",
+            }}
+          >
+            Sign in
+          </Link>
         </header>
 
         {!hideHero && (
           <section className="premium-fade-up" style={{ display: "grid", gap: 20 }}>
             {eyebrow && (
-              <p style={{ margin: 0, fontSize: 10, fontWeight: 600, letterSpacing: "0.24em", textTransform: "uppercase", color: accent }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 10,
+                  fontWeight: 600,
+                  letterSpacing: "0.24em",
+                  textTransform: "uppercase",
+                  color: accent,
+                }}
+              >
                 {eyebrow}
               </p>
             )}
-            <h1 style={{ margin: 0, fontSize: "clamp(2.5rem, 5vw, 4.5rem)", fontWeight: 500, letterSpacing: "-0.04em", lineHeight: 1, color: "white" }}>
+            <h1
+              style={{
+                margin: 0,
+                fontSize: "clamp(2.5rem, 5vw, 4.5rem)",
+                fontWeight: 500,
+                letterSpacing: "-0.04em",
+                lineHeight: 1,
+                color: "white",
+              }}
+            >
               {title}
             </h1>
-            <p style={{ margin: 0, maxWidth: 600, fontSize: 18, lineHeight: 1.6, color: "rgba(245, 245, 245, 0.6)", fontWeight: 300 }}>
+            <p
+              style={{
+                margin: 0,
+                maxWidth: 680,
+                fontSize: 18,
+                lineHeight: 1.6,
+                color: "rgba(245, 245, 245, 0.6)",
+                fontWeight: 300,
+              }}
+            >
               {description}
             </p>
           </section>
         )}
 
-        <div style={{ minHeight: "60vh" }}>
-          {children}
-        </div>
+        <div style={{ minHeight: "60vh" }}>{children}</div>
 
         <footer style={{ marginTop: 80, paddingTop: 40, borderTop: "1px solid rgba(255, 255, 255, 0.08)" }}>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: 40 }}>
-            <div style={{ display: "grid", gap: 16, maxWidth: 360 }}>
-              <div style={{ fontSize: 14, fontWeight: 600, letterSpacing: "0.1em", textTransform: "uppercase", color: "white" }}>DEFRAG</div>
+            <div style={{ display: "grid", gap: 16, maxWidth: 420 }}>
+              <div style={{ fontSize: 14, fontWeight: 600, letterSpacing: "0.1em", textTransform: "uppercase", color: "white" }}>
+                DEFRAG
+              </div>
               <p style={{ margin: 0, fontSize: 14, lineHeight: 1.6, color: "rgba(245, 245, 245, 0.5)" }}>
-                DEFRAG helps you catch the pattern, lower the pressure, and change what happens next.
+                Defrag helps people understand difficult interactions by showing what may be happening, where pressure changed, and what to do next.
               </p>
             </div>
-            
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 120px)", gap: 40 }}>
-               <div style={{ display: "grid", gap: 12 }}>
-                  <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.3)" }}>Product</div>
-                  {navItems.map(item => <Link key={item.href} href={item.href} style={{ fontSize: 13, textDecoration: "none", color: "rgba(245,245,245,0.6)" }}>{item.label}</Link>)}
-               </div>
-               <div style={{ display: "grid", gap: 12 }}>
-                  <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.3)" }}>Legal</div>
-                  {footerItems.slice(2, 4).map(item => <Link key={item.href} href={item.href} style={{ fontSize: 13, textDecoration: "none", color: "rgba(245,245,245,0.6)" }}>{item.label}</Link>)}
-               </div>
+
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 140px)", gap: 40 }}>
+              <div style={{ display: "grid", gap: 12 }}>
+                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.3)" }}>
+                  Explore
+                </div>
+                {navItems.slice(0, 3).map((item) => (
+                  <Link key={item.href} href={item.href} style={{ fontSize: 13, textDecoration: "none", color: "rgba(245,245,245,0.6)" }}>
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+              <div style={{ display: "grid", gap: 12 }}>
+                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.3)" }}>
+                  Legal
+                </div>
+                {footerItems.slice(2, 4).map((item) => (
+                  <Link key={item.href} href={item.href} style={{ fontSize: 13, textDecoration: "none", color: "rgba(245,245,245,0.6)" }}>
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
             </div>
           </div>
-          <div style={{ marginTop: 64, fontSize: 12, color: "rgba(245, 245, 245, 0.3)" }}>
-            © 2026 DEFRAG. Built for high-stakes interactions.
-          </div>
+          <div style={{ marginTop: 64, fontSize: 12, color: "rgba(245, 245, 245, 0.3)" }}>© 2026 DEFRAG.</div>
         </footer>
       </div>
 


### PR DESCRIPTION
This tightens two user-facing surfaces that still read too much like a software shell.

Changes include:
- replacing generic nav labels like Product and Pricing with clearer language
- removing the Active status pill from the public header
- simplifying footer navigation
- reframing plans into clearer access tiers
- softening remaining SaaS subscription language on the plans page

The goal is to make the site feel more like a serious product company and less like a generic app shell.