### PR TITLE
refine: align interior shell and trust pages with homepage redesign

### DIFF
--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -2,18 +2,22 @@ import { AppShell } from "../../components/app-shell";
 
 const sections = [
   {
+    number: "01",
     title: "What we collect",
     body: "Defrag uses the information you provide, your account details, and your plan status to keep your workspace running and deliver the product experience.",
   },
   {
+    number: "02",
     title: "How we use it",
     body: "We use your information to support sign-in, save your workspace, deliver insights, and keep your account working as expected.",
   },
   {
+    number: "03",
     title: "Billing",
     body: "Payments and subscription changes are handled through Defrag and our payment provider. Billing details are used only to process and manage your plan.",
   },
   {
+    number: "04",
     title: "Security and control",
     body: "We use authentication, access controls, and plan checks to protect your account. You control what you choose to keep, use, and share.",
   },
@@ -25,21 +29,40 @@ export default function PrivacyPage() {
       eyebrow="Privacy"
       title="Privacy should be clear and easy to understand."
       description="This page explains what Defrag uses, why it uses it, and how your account stays protected."
-      accent="#22d3ee"
+      accent="var(--color-accent)"
     >
-      <div style={{ maxWidth: 760, display: "grid", gap: 48 }}>
-        {sections.map((section, i) => (
-          <div key={section.title} style={{ display: "grid", gap: 14 }}>
-            <div style={{ display: "flex", alignItems: "baseline", gap: 14, flexWrap: "wrap" }}>
-              <span style={{ fontSize: 12, color: "rgba(245,245,245,0.3)", fontWeight: 500 }}>{String(i + 1).padStart(2, "0")}</span>
-              <h2 style={{ margin: 0, fontSize: 22, fontWeight: 500, color: "white" }}>{section.title}</h2>
-            </div>
-            <p style={{ margin: 0, paddingLeft: 32, color: "rgba(245,245,245,0.65)", lineHeight: 1.8, fontSize: 16, fontWeight: 300 }}>
-              {section.body}
-            </p>
+      <div style={{ maxWidth: 1120, display: "grid", gridTemplateColumns: "220px minmax(0,1fr)", gap: 48 }} className="privacy-grid">
+        <aside style={{ display: "grid", gap: 16, alignContent: "start" }}>
+          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245,245,245,0.38)" }}>
+            What this page explains
           </div>
-        ))}
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.72, color: "rgba(245,245,245,0.52)" }}>
+            What Defrag uses to run the product, why that information matters, and how access stays controlled.
+          </p>
+        </aside>
+
+        <div style={{ display: "grid", gap: 0, borderTop: "1px solid rgba(255,255,255,0.08)" }}>
+          {sections.map((section) => (
+            <div key={section.title} style={{ display: "grid", gridTemplateColumns: "70px minmax(0,1fr)", gap: 16, paddingTop: 22, paddingBottom: 24, borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
+              <div style={{ fontSize: 11, color: "rgba(245,245,245,0.3)", fontWeight: 600, letterSpacing: "0.1em" }}>{section.number}</div>
+              <div style={{ display: "grid", gap: 10 }}>
+                <h2 style={{ margin: 0, fontSize: 28, fontWeight: 500, color: "white", lineHeight: 1.08 }}>
+                  {section.title}
+                </h2>
+                <p style={{ margin: 0, color: "rgba(245,245,245,0.64)", lineHeight: 1.8, fontSize: 16, fontWeight: 300, maxWidth: 760 }}>
+                  {section.body}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
+
+      <style>{`
+        @media (max-width: 900px) {
+          .privacy-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
     </AppShell>
   );
 }

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -2,18 +2,22 @@ import { AppShell } from "../../components/app-shell";
 
 const sections = [
   {
+    number: "01",
     title: "Using Defrag",
     body: "Defrag helps you think through difficult interactions more clearly. It is not emergency support, legal advice, medical advice, or a substitute for licensed care.",
   },
   {
+    number: "02",
     title: "Accounts",
     body: "You are responsible for keeping your sign-in method secure and for using your account in a lawful and respectful way.",
   },
   {
+    number: "03",
     title: "Plans and billing",
     body: "If you choose a paid plan, billing and subscription changes are handled through Defrag and our payment provider.",
   },
   {
+    number: "04",
     title: "Acceptable use",
     body: "You may not misuse the product, interfere with the service, try to bypass access controls, or use Defrag in a way that harms others or breaks the law.",
   },
@@ -24,22 +28,41 @@ export default function TermsPage() {
     <AppShell
       eyebrow="Terms"
       title="Terms should be straightforward."
-      description="These terms explain the basic rules for using Defrag, keeping your account secure, and managing paid access."
-      accent="rgba(245, 245, 245, 0.5)"
+      description="These terms explain the core rules for using Defrag, keeping your account secure, and managing paid access."
+      accent="rgba(245, 245, 245, 0.56)"
     >
-      <div style={{ maxWidth: 760, display: "grid", gap: 48 }}>
-        {sections.map((section, i) => (
-          <div key={section.title} style={{ display: "grid", gap: 14 }}>
-            <div style={{ display: "flex", alignItems: "baseline", gap: 14, flexWrap: "wrap" }}>
-              <span style={{ fontSize: 12, color: "rgba(245,245,245,0.3)", fontWeight: 500 }}>{String(i + 1).padStart(2, "0")}</span>
-              <h2 style={{ margin: 0, fontSize: 22, fontWeight: 500, color: "white" }}>{section.title}</h2>
-            </div>
-            <p style={{ margin: 0, paddingLeft: 32, color: "rgba(245,245,245,0.65)", lineHeight: 1.8, fontSize: 16, fontWeight: 300 }}>
-              {section.body}
-            </p>
+      <div style={{ maxWidth: 1120, display: "grid", gridTemplateColumns: "220px minmax(0,1fr)", gap: 48 }} className="terms-grid">
+        <aside style={{ display: "grid", gap: 16, alignContent: "start" }}>
+          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245,245,245,0.38)" }}>
+            What these terms cover
           </div>
-        ))}
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.72, color: "rgba(245,245,245,0.52)" }}>
+            How to use Defrag appropriately, how accounts are handled, and how paid access is managed.
+          </p>
+        </aside>
+
+        <div style={{ display: "grid", gap: 0, borderTop: "1px solid rgba(255,255,255,0.08)" }}>
+          {sections.map((section) => (
+            <div key={section.title} style={{ display: "grid", gridTemplateColumns: "70px minmax(0,1fr)", gap: 16, paddingTop: 22, paddingBottom: 24, borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
+              <div style={{ fontSize: 11, color: "rgba(245,245,245,0.3)", fontWeight: 600, letterSpacing: "0.1em" }}>{section.number}</div>
+              <div style={{ display: "grid", gap: 10 }}>
+                <h2 style={{ margin: 0, fontSize: 28, fontWeight: 500, color: "white", lineHeight: 1.08 }}>
+                  {section.title}
+                </h2>
+                <p style={{ margin: 0, color: "rgba(245,245,245,0.64)", lineHeight: 1.8, fontSize: 16, fontWeight: 300, maxWidth: 760 }}>
+                  {section.body}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
+
+      <style>{`
+        @media (max-width: 900px) {
+          .terms-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
     </AppShell>
   );
 }

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -18,7 +18,7 @@ export function AppShell({
   title,
   description,
   children,
-  accent = "#22d3ee",
+  accent = "var(--color-accent)",
   hideHero = false,
 }: AppShellProps) {
   const pathname = usePathname();
@@ -44,18 +44,18 @@ export function AppShell({
         color: "#f5f5f5",
         backgroundColor: "#050505",
         backgroundImage:
-          "radial-gradient(circle at 0% 0%, rgba(34, 211, 238, 0.04), transparent 30%), radial-gradient(circle at 100% 0%, rgba(79, 70, 229, 0.03), transparent 30%)",
+          "radial-gradient(circle at 0% 0%, rgba(159,179,164,0.05), transparent 28%), radial-gradient(circle at 100% 0%, rgba(255,255,255,0.04), transparent 20%)",
         backgroundAttachment: "fixed",
       }}
     >
       <div
         className="app-shell-frame"
         style={{
-          maxWidth: 1200,
+          maxWidth: 1280,
           margin: "0 auto",
-          padding: "40px 24px 80px",
+          padding: "48px 24px 88px",
           display: "grid",
-          gap: 64,
+          gap: 84,
         }}
       >
         <header
@@ -63,26 +63,25 @@ export function AppShell({
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
-            paddingBottom: 0,
             gap: 24,
           }}
         >
-          <div style={{ display: "flex", alignItems: "center", gap: 32 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 34 }}>
             <Link
               href="/"
               style={{
                 textDecoration: "none",
                 color: "white",
-                fontSize: 16,
+                fontSize: 15,
                 fontWeight: 600,
-                letterSpacing: "0.2em",
+                letterSpacing: "0.22em",
                 textTransform: "uppercase",
               }}
             >
               DEFRAG
             </Link>
 
-            <nav style={{ display: "flex", gap: 24 }} className="desktop-nav">
+            <nav style={{ display: "flex", gap: 22 }} className="desktop-nav">
               {navItems.map((item) => {
                 const active = item.match(pathname);
                 return (
@@ -93,7 +92,7 @@ export function AppShell({
                       textDecoration: "none",
                       fontSize: 13,
                       fontWeight: 500,
-                      color: active ? "white" : "rgba(245, 245, 245, 0.45)",
+                      color: active ? "white" : "rgba(245, 245, 245, 0.48)",
                       transition: "color 0.2s ease",
                     }}
                   >
@@ -111,10 +110,10 @@ export function AppShell({
               fontWeight: 500,
               color: "white",
               textDecoration: "none",
-              padding: "8px 16px",
-              borderRadius: 12,
+              padding: "10px 18px",
+              borderRadius: 14,
               border: "1px solid rgba(255,255,255,0.1)",
-              background: "rgba(245,245,245,0.05)",
+              background: "rgba(245,245,245,0.04)",
             }}
           >
             Sign in
@@ -122,13 +121,13 @@ export function AppShell({
         </header>
 
         {!hideHero && (
-          <section className="premium-fade-up" style={{ display: "grid", gap: 20 }}>
+          <section className="premium-fade-up" style={{ display: "grid", gap: 18, maxWidth: 980 }}>
             {eyebrow && (
               <p
                 style={{
                   margin: 0,
                   fontSize: 10,
-                  fontWeight: 600,
+                  fontWeight: 700,
                   letterSpacing: "0.24em",
                   textTransform: "uppercase",
                   color: accent,
@@ -138,13 +137,13 @@ export function AppShell({
               </p>
             )}
             <h1
+              className="font-display"
               style={{
                 margin: 0,
-                fontSize: "clamp(2.5rem, 5vw, 4.5rem)",
-                fontWeight: 500,
-                letterSpacing: "-0.04em",
-                lineHeight: 1,
+                fontSize: "clamp(3.6rem, 7vw, 6.4rem)",
+                lineHeight: 0.9,
                 color: "white",
+                maxWidth: 980,
               }}
             >
               {title}
@@ -152,10 +151,10 @@ export function AppShell({
             <p
               style={{
                 margin: 0,
-                maxWidth: 680,
+                maxWidth: 760,
                 fontSize: 18,
-                lineHeight: 1.6,
-                color: "rgba(245, 245, 245, 0.6)",
+                lineHeight: 1.72,
+                color: "rgba(245, 245, 245, 0.62)",
                 fontWeight: 300,
               }}
             >
@@ -164,22 +163,22 @@ export function AppShell({
           </section>
         )}
 
-        <div style={{ minHeight: "60vh" }}>{children}</div>
+        <div style={{ minHeight: "56vh" }}>{children}</div>
 
-        <footer style={{ marginTop: 80, paddingTop: 40, borderTop: "1px solid rgba(255, 255, 255, 0.08)" }}>
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: 40 }}>
-            <div style={{ display: "grid", gap: 16, maxWidth: 420 }}>
-              <div style={{ fontSize: 14, fontWeight: 600, letterSpacing: "0.1em", textTransform: "uppercase", color: "white" }}>
+        <footer style={{ marginTop: 48, paddingTop: 34, borderTop: "1px solid rgba(255, 255, 255, 0.08)" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: 48 }}>
+            <div style={{ display: "grid", gap: 14, maxWidth: 420 }}>
+              <div style={{ fontSize: 14, fontWeight: 600, letterSpacing: "0.14em", textTransform: "uppercase", color: "white" }}>
                 DEFRAG
               </div>
-              <p style={{ margin: 0, fontSize: 14, lineHeight: 1.6, color: "rgba(245, 245, 245, 0.5)" }}>
+              <p style={{ margin: 0, fontSize: 14, lineHeight: 1.72, color: "rgba(245, 245, 245, 0.5)" }}>
                 Defrag helps people understand difficult interactions by showing what may be happening, where pressure changed, and what to do next.
               </p>
             </div>
 
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 140px)", gap: 40 }}>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 150px)", gap: 40 }}>
               <div style={{ display: "grid", gap: 12 }}>
-                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.3)" }}>
+                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.34)" }}>
                   Explore
                 </div>
                 {navItems.slice(0, 3).map((item) => (
@@ -189,7 +188,7 @@ export function AppShell({
                 ))}
               </div>
               <div style={{ display: "grid", gap: 12 }}>
-                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.3)" }}>
+                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.34)" }}>
                   Legal
                 </div>
                 {footerItems.slice(2, 4).map((item) => (
@@ -200,21 +199,14 @@ export function AppShell({
               </div>
             </div>
           </div>
-          <div style={{ marginTop: 64, fontSize: 12, color: "rgba(245, 245, 245, 0.3)" }}>© 2026 DEFRAG.</div>
+          <div style={{ marginTop: 54, fontSize: 12, color: "rgba(245, 245, 245, 0.28)" }}>© 2026 DEFRAG.</div>
         </footer>
       </div>
 
       <style>{`
         @media (max-width: 768px) {
           .desktop-nav { display: none !important; }
-          .app-shell-frame { padding: 24px 16px 40px !important; gap: 40px !important; }
-        }
-        .premium-fade-up {
-          animation: fadeUp 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-        }
-        @keyframes fadeUp {
-          from { opacity: 0; transform: translateY(20px); }
-          to { opacity: 1; transform: translateY(0); }
+          .app-shell-frame { padding: 24px 16px 44px !important; gap: 48px !important; }
         }
       `}</style>
     </main>


### PR DESCRIPTION
This pass carries the stronger homepage art direction into the rest of the public site.

Changes include:
- a more premium shared shell for interior pages
- stronger hero treatment and spacing for interior routes
- editorial trust-page layouts for Terms and Privacy
- better visual continuity between the homepage and lower-priority public pages

The goal is to stop the site from feeling like only the homepage was redesigned.