### PR TITLE
feat(web): replace homepage with premium DEFRAG landing page

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,154 +1,419 @@
 "use client";
 
 import Link from "next/link";
-import { AppShell } from "../components/app-shell";
-import { ArrowRight } from "lucide-react";
 
-const offerings = [
-  {
-    title: "Personal pattern analysis",
-    body: "Understand how you tend to process tension, communication, pacing, and recurring pressure across relationships.",
-  },
-  {
-    title: "1:1 interaction analysis",
-    body: "Assess a difficult interaction between two people, including where pressure changed, what may be getting misread, and what move makes sense next.",
-  },
-  {
-    title: "1:many and system analysis",
-    body: "Assess families, teams, and multi-person systems where communication and emotional pressure move across more than two people.",
-  },
-  {
-    title: "Perspective comparison",
-    body: "Compare what each side may be experiencing, protecting, projecting, or misreading instead of reinforcing only one narrator's story.",
-  },
-  {
-    title: "Communication guidance",
-    body: "Get wording designed to lower pressure, preserve truth, and increase the chance of being understood clearly.",
-  },
-  {
-    title: "Simulation and timing",
-    body: "Explore likely relational reactions before a conversation happens and understand when a moment calls for repair, space, or delay.",
-  },
-];
+const recognitionPairs = [
+  ["What feels urgent to you", "may feel overwhelming to someone else."],
+  ["What feels like clarity", "may land as pressure."],
+  ["What feels like silence", "may actually be processing."],
+  ["What feels like distance", "may be someone protecting stability."],
+] as const;
 
-const outputs = [
-  "what may be happening",
-  "how each side may be reading it",
-  "where pressure changed",
-  "what pattern is forming",
-  "what may be getting misread",
-  "what to try next",
-];
+const guidanceBullets = [
+  "when pressure is rising",
+  "how you are likely to respond",
+  "when not to push",
+  "when clarity is better received",
+  "how to protect important relationships through timing",
+] as const;
 
-export default function LandingPage() {
+const steps = [
+  "Create your account",
+  "Enter your birth date, time, and place",
+  "DEFRAG generates your baseline design profile",
+  "The platform tracks active timing and relational pressure",
+  "You receive subtle guidance, daily audio, and in-app intelligence designed to help you communicate with better timing",
+] as const;
+
+const dailyReadBullets = [
+  "the current relational climate",
+  "what to avoid",
+  "what supports clarity",
+  "whether to lean in, wait, simplify, or pause",
+] as const;
+
+const baselineSystems = ["astrology", "human design", "numerology", "I Ching", "Gene Keys"] as const;
+
+const longTermBullets = [
+  "recognize repeating pressure patterns",
+  "understand their own pacing",
+  "reduce avoidable conflict",
+  "protect important relationships",
+  "build trust through better timing and less force",
+] as const;
+
+export default function HomePage() {
   return (
-    <AppShell eyebrow="" title="" description="" hideHero={true}>
-      <div style={{ display: "grid", gap: 120, padding: "40px 8px 110px" }}>
-        <section style={{ maxWidth: 1320, margin: "0 auto", width: "100%", display: "grid", gap: 28 }}>
-          <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1.08fr) minmax(360px, 0.92fr)", gap: 34, alignItems: "stretch" }} className="hero-grid">
-            <div style={{ display: "grid", gap: 24, alignContent: "start", paddingTop: 18 }}>
-              <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.22em", textTransform: "uppercase", color: "rgba(245,245,245,0.42)" }}>
-                Relational Intelligence Infrastructure
-              </div>
-              <h1 className="font-display" style={{ margin: 0, fontSize: "clamp(4.5rem, 9vw, 8.6rem)", lineHeight: 0.82, color: "white", maxWidth: 920 }}>
-                Understand what is happening between people before it hardens into damage.
-              </h1>
-              <p style={{ margin: 0, maxWidth: 760, fontSize: "clamp(1.08rem, 1.95vw, 1.32rem)", lineHeight: 1.76, color: "rgba(245,245,245,0.68)", fontWeight: 300 }}>
-                Defrag is a relational intelligence platform for understanding conflict, communication breakdown, emotional pressure, timing, and perspective differences across individuals, pairs, families, and teams.
-              </p>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 14, paddingTop: 8 }}>
-                <Link href="/login" style={{ display: "inline-flex", alignItems: "center", gap: 10, background: "white", color: "#050505", padding: "16px 28px", fontWeight: 600, fontSize: 15, textDecoration: "none" }}>
-                  Open Defrag
-                  <ArrowRight style={{ width: 18, height: 18 }} />
-                </Link>
-                <Link href="/about" style={{ display: "inline-flex", alignItems: "center", gap: 10, background: "transparent", color: "white", border: "1px solid rgba(255,255,255,0.12)", padding: "16px 28px", fontWeight: 500, fontSize: 15, textDecoration: "none" }}>
-                  See how it works
-                </Link>
-              </div>
+    <main className="homepage">
+      <header className="site-header reveal">
+        <div className="brand">DEFRAG</div>
+        <nav aria-label="Primary navigation" className="site-nav">
+          <a href="#how-it-works">How It Works</a>
+          <Link href="/login">Log In</Link>
+          <Link href="/login" className="cta-small">
+            Create Account
+          </Link>
+        </nav>
+      </header>
+
+      <section className="hero reveal">
+        <h1 className="font-display">Know when to lean in, when to wait, and how to avoid unnecessary damage.</h1>
+        <p>
+          DEFRAG uses your natal design and active timing cycles to help you navigate relationships with better pacing, clearer
+          perception, and fewer preventable ruptures.
+        </p>
+        <div className="hero-actions">
+          <Link href="/login" className="cta-primary">
+            Create Account
+          </Link>
+          <a href="#how-it-works" className="cta-secondary">
+            See How It Works
+          </a>
+        </div>
+      </section>
+
+      <section className="section reveal">
+        <h2 className="font-display">The wrong conversation at the wrong time can change everything.</h2>
+        <div className="pair-grid">
+          {recognitionPairs.map(([lead, follow]) => (
+            <div className="pair-card" key={lead}>
+              <p className="pair-lead">{lead}</p>
+              <p className="pair-follow">{follow}</p>
             </div>
+          ))}
+        </div>
+        <p className="section-close">DEFRAG helps you recognize the difference before tension becomes damage.</p>
+      </section>
 
-            <div style={{ position: "relative", minHeight: 640, border: "1px solid rgba(255,255,255,0.08)", background: "linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.01))", overflow: "hidden" }}>
-              <div style={{ position: "absolute", inset: 0, background: "radial-gradient(circle at 16% 18%, rgba(159,179,164,0.22), transparent 22%), radial-gradient(circle at 78% 16%, rgba(255,255,255,0.1), transparent 16%), linear-gradient(140deg, rgba(255,255,255,0.05), transparent 45%, rgba(159,179,164,0.05) 70%, transparent 100%)" }} />
-              <div style={{ position: "absolute", left: "8%", right: "8%", top: "14%", height: 1, background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.22), transparent)" }} />
-              <div style={{ position: "absolute", left: "14%", top: "20%", width: "44%", padding: "18px 18px 18px 20px", borderLeft: "1px solid rgba(255,255,255,0.16)", background: "rgba(255,255,255,0.02)", boxShadow: "0 24px 60px rgba(0,0,0,0.28)" }}>
-                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.16em", textTransform: "uppercase", color: "rgba(245,245,245,0.38)", marginBottom: 10 }}>Signal</div>
-                <div style={{ fontSize: 20, lineHeight: 1.4, color: "white" }}>A pause may signal overload, not rejection.</div>
-              </div>
-              <div style={{ position: "absolute", right: "10%", top: "34%", width: "48%", padding: "18px 18px 18px 20px", borderLeft: "1px solid rgba(255,255,255,0.14)", background: "rgba(255,255,255,0.025)", boxShadow: "0 24px 60px rgba(0,0,0,0.24)" }}>
-                <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.16em", textTransform: "uppercase", color: "rgba(245,245,245,0.38)", marginBottom: 10 }}>Pressure shift</div>
-                <div style={{ fontSize: 18, lineHeight: 1.45, color: "rgba(245,245,245,0.92)" }}>Fast pacing can turn clarity into pressure before either side realizes it.</div>
-              </div>
-              <div style={{ position: "absolute", left: "12%", right: "12%", bottom: "11%", display: "grid", gap: 12 }}>
-                <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0,1fr))", gap: 10 }} className="hero-mini-grid">
-                  {[
-                    "perspective",
-                    "pressure",
-                    "timing",
-                  ].map((label) => (
-                    <div key={label} style={{ padding: "12px 10px", borderTop: "1px solid rgba(255,255,255,0.12)", color: "rgba(245,245,245,0.86)", fontSize: 12, letterSpacing: "0.06em", textTransform: "uppercase" }}>
-                      {label}
-                    </div>
-                  ))}
-                </div>
-                <div style={{ padding: "16px 18px", border: "1px solid rgba(255,255,255,0.08)", background: "rgba(0,0,0,0.2)", fontSize: 14, lineHeight: 1.72, color: "rgba(245,245,245,0.9)" }}>
-                  The next move should lower distortion before it adds more meaning.
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
+      <section className="section reveal">
+        <h2 className="font-display">Personalized relational guidance, timed to the moment.</h2>
+        <p>
+          DEFRAG builds a baseline design from your birth data, tracks active timing pressure, and translates both into practical
+          guidance for communication, pacing, and relational decision-making.
+        </p>
+        <p>It helps you understand:</p>
+        <ul>
+          {guidanceBullets.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
 
-        <section style={{ maxWidth: 1320, margin: "0 auto", width: "100%", display: "grid", gridTemplateColumns: "240px minmax(0,1fr)", gap: 34 }} className="section-grid">
-          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: "rgba(245,245,245,0.38)" }}>
-            What Defrag returns
-          </div>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0,1fr))", gap: 18 }} className="outputs-grid">
-            {outputs.map((item) => (
-              <div key={item} style={{ paddingTop: 14, borderTop: "1px solid rgba(255,255,255,0.08)", fontSize: 14, lineHeight: 1.58, color: "rgba(245,245,245,0.88)" }}>
-                {item}
-              </div>
-            ))}
-          </div>
-        </section>
+      <section id="how-it-works" className="section reveal" aria-labelledby="how-it-works-title">
+        <h2 id="how-it-works-title" className="font-display">
+          How it works
+        </h2>
+        <ol>
+          {steps.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+      </section>
 
-        <section style={{ maxWidth: 1320, margin: "0 auto", width: "100%", display: "grid", gridTemplateColumns: "280px minmax(0,1fr)", gap: 46 }} className="section-grid">
-          <div>
-            <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.22em", textTransform: "uppercase", color: "var(--color-accent)" }}>Why Defrag exists</div>
-          </div>
-          <div style={{ display: "grid", gap: 18, maxWidth: 920 }}>
-            <p className="font-display" style={{ margin: 0, fontSize: "clamp(2.7rem, 5vw, 4.7rem)", lineHeight: 0.94, color: "white" }}>
-              Most people do not need more opinion layered onto a difficult moment. They need clearer structure.
-            </p>
-            <p style={{ margin: 0, fontSize: 17, lineHeight: 1.84, color: "rgba(245,245,245,0.64)" }}>
-              People can feel tension, repetition, misalignment, and escalation, but they often cannot identify what activated it, why the same pattern keeps returning, or what next move would actually help. Defrag exists to make those structures visible before confusion becomes distance, silence, or conflict that hardens.
-            </p>
-          </div>
-        </section>
+      <section className="section reveal">
+        <h2 className="font-display">A daily read for the moments that matter.</h2>
+        <p>Each day, DEFRAG can generate a short audio and written guidance layer based on your design and timing.</p>
+        <p>It tells you:</p>
+        <ul>
+          {dailyReadBullets.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
 
-        <section style={{ maxWidth: 1320, margin: "0 auto", width: "100%", display: "grid", gap: 30 }}>
-          <div style={{ display: "grid", gap: 12, maxWidth: 900 }}>
-            <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.22em", textTransform: "uppercase", color: "var(--color-accent)" }}>What users can access</div>
-            <h2 className="font-display" style={{ margin: 0, fontSize: "clamp(2.8rem, 5vw, 4.8rem)", lineHeight: 0.94, color: "white" }}>
-              Core relational intelligence capabilities.
-            </h2>
-          </div>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0,1fr))", gap: 0, borderTop: "1px solid rgba(255,255,255,0.08)" }} className="offerings-grid">
-            {offerings.map((item, index) => (
-              <div key={item.title} style={{ paddingTop: 26, paddingBottom: 30, paddingRight: index % 2 === 0 ? 30 : 0, paddingLeft: index % 2 === 1 ? 30 : 0, borderBottom: "1px solid rgba(255,255,255,0.08)", borderLeft: index % 2 === 1 ? "1px solid rgba(255,255,255,0.08)" : "none", display: "grid", gap: 12 }}>
-                <div style={{ fontSize: 18, fontWeight: 600, color: "white", lineHeight: 1.34 }}>{item.title}</div>
-                <p style={{ margin: 0, fontSize: 14, lineHeight: 1.82, color: "rgba(245,245,245,0.62)", maxWidth: 540 }}>{item.body}</p>
-              </div>
-            ))}
-          </div>
-        </section>
-      </div>
+      <section className="section reveal">
+        <h2 className="font-display">Built on a deeper profile than ordinary apps.</h2>
+        <p>DEFRAG synthesizes:</p>
+        <ul>
+          {baselineSystems.map((system) => (
+            <li key={system}>{system}</li>
+          ))}
+        </ul>
+        <p>into one coherent baseline model that supports timing-aware relational guidance.</p>
+        <p>The product translates these systems into practical language people can use in everyday life.</p>
+      </section>
+
+      <section className="section reveal">
+        <h2 className="font-display">Better timing creates better relationships.</h2>
+        <p>Over time, DEFRAG helps users:</p>
+        <ul>
+          {longTermBullets.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="final-cta reveal" aria-labelledby="final-cta-title">
+        <h2 id="final-cta-title" className="font-display">
+          Build your DEFRAG profile.
+        </h2>
+        <p>Create your account, generate your design, and begin receiving timing-aware relational guidance.</p>
+        <Link href="/login" className="cta-primary">
+          Create Account
+        </Link>
+      </section>
+
+      <footer className="site-footer">
+        <div>© 2026 DEFRAG</div>
+        <div className="footer-links">
+          <Link href="/terms">Terms</Link>
+          <Link href="/privacy">Privacy</Link>
+          <Link href="/login">Log In</Link>
+        </div>
+      </footer>
 
       <style>{`
-        @media (max-width: 1080px) {
-          .hero-grid, .section-grid, .outputs-grid, .offerings-grid, .hero-mini-grid { grid-template-columns: 1fr !important; }
-          .offerings-grid > div { padding-left: 0 !important; padding-right: 0 !important; border-left: none !important; }
+        :root {
+          --obsidian: #080808;
+          --carbon: #111111;
+          --graphite: #1a1a1a;
+          --smoke: #2b2b2b;
+          --bone: #f5f3ee;
+          --soft-white: #eae7e0;
+          --steel: #8e949b;
+          --lunar: #63676d;
+          --deep-blue-black: #0e1320;
+          --gold-ash: #a38a63;
+          --pearl: #bfc6cf;
+        }
+
+        .homepage {
+          max-width: 1140px;
+          margin: 0 auto;
+          padding: 20px 16px 80px;
+          color: var(--soft-white);
+          display: grid;
+          gap: 72px;
+        }
+
+        .site-header {
+          position: sticky;
+          top: 0;
+          z-index: 20;
+          backdrop-filter: blur(10px);
+          background: linear-gradient(180deg, rgba(8, 8, 8, 0.94), rgba(8, 8, 8, 0.82));
+          border: 1px solid rgba(142, 148, 155, 0.24);
+          display: flex;
+          flex-wrap: wrap;
+          gap: 16px;
+          align-items: center;
+          justify-content: space-between;
+          padding: 14px 16px;
+        }
+
+        .brand {
+          font-size: 0.78rem;
+          letter-spacing: 0.22em;
+          text-transform: uppercase;
+          color: var(--bone);
+          font-weight: 700;
+        }
+
+        .site-nav {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+          flex-wrap: wrap;
+        }
+
+        .site-nav a {
+          color: var(--soft-white);
+          border: 1px solid transparent;
+          padding: 8px 12px;
+          font-size: 0.9rem;
+        }
+
+        .cta-small {
+          border-color: rgba(163, 138, 99, 0.5) !important;
+          background: rgba(163, 138, 99, 0.12);
+        }
+
+        .hero {
+          background: radial-gradient(circle at 70% 0%, rgba(14, 19, 32, 0.72), transparent 42%),
+            linear-gradient(180deg, rgba(17, 17, 17, 0.96), rgba(8, 8, 8, 0.96));
+          border: 1px solid rgba(142, 148, 155, 0.28);
+          padding: 40px 22px;
+          display: grid;
+          gap: 20px;
+        }
+
+        .hero h1 {
+          font-size: clamp(2.1rem, 8vw, 4.8rem);
+          line-height: 0.95;
+          color: var(--bone);
+        }
+
+        .hero p,
+        .section p,
+        li {
+          color: var(--soft-white);
+          line-height: 1.75;
+          font-size: clamp(1rem, 2.4vw, 1.15rem);
+          max-width: 72ch;
+        }
+
+        .hero-actions {
+          display: flex;
+          gap: 12px;
+          flex-wrap: wrap;
+        }
+
+        .cta-primary,
+        .cta-secondary {
+          padding: 12px 18px;
+          border: 1px solid rgba(142, 148, 155, 0.44);
+          font-weight: 600;
+          color: var(--bone);
+          width: fit-content;
+        }
+
+        .cta-primary {
+          background: rgba(191, 198, 207, 0.11);
+          border-color: rgba(191, 198, 207, 0.44);
+        }
+
+        .cta-secondary {
+          background: rgba(43, 43, 43, 0.38);
+        }
+
+        .section,
+        .final-cta {
+          border-top: 1px solid rgba(142, 148, 155, 0.28);
+          padding-top: 28px;
+          display: grid;
+          gap: 18px;
+        }
+
+        .section h2,
+        .final-cta h2 {
+          color: var(--bone);
+          font-size: clamp(1.9rem, 7vw, 3.6rem);
+          line-height: 1;
+        }
+
+        .pair-grid {
+          display: grid;
+          gap: 12px;
+        }
+
+        .pair-card {
+          border: 1px solid rgba(99, 103, 109, 0.5);
+          background: linear-gradient(180deg, rgba(26, 26, 26, 0.6), rgba(17, 17, 17, 0.45));
+          padding: 16px;
+        }
+
+        .pair-lead {
+          color: var(--bone);
+          font-weight: 600;
+        }
+
+        .pair-follow {
+          color: var(--steel);
+        }
+
+        .section-close {
+          color: var(--pearl);
+        }
+
+        ul,
+        ol {
+          margin: 0;
+          padding-left: 22px;
+          display: grid;
+          gap: 10px;
+        }
+
+        ol li::marker,
+        ul li::marker {
+          color: var(--gold-ash);
+        }
+
+        .final-cta {
+          background: linear-gradient(180deg, rgba(14, 19, 32, 0.5), rgba(17, 17, 17, 0.3));
+          border: 1px solid rgba(142, 148, 155, 0.28);
+          padding: 28px 20px;
+        }
+
+        .site-footer {
+          border-top: 1px solid rgba(142, 148, 155, 0.26);
+          padding-top: 20px;
+          color: var(--steel);
+          display: flex;
+          justify-content: space-between;
+          gap: 12px;
+          flex-wrap: wrap;
+        }
+
+        .footer-links {
+          display: flex;
+          gap: 12px;
+          flex-wrap: wrap;
+        }
+
+        a:focus-visible {
+          outline: 2px solid var(--pearl);
+          outline-offset: 2px;
+          border-color: var(--pearl);
+        }
+
+        .reveal {
+          animation: revealBlur 560ms ease-out both;
+        }
+
+        @keyframes revealBlur {
+          from {
+            opacity: 0;
+            filter: blur(6px);
+            transform: translateY(8px);
+          }
+          to {
+            opacity: 1;
+            filter: blur(0px);
+            transform: translateY(0px);
+          }
+        }
+
+        @media (min-width: 900px) {
+          .homepage {
+            padding: 34px 28px 120px;
+            gap: 94px;
+          }
+
+          .pair-grid {
+            grid-template-columns: 1fr 1fr;
+          }
+
+          .site-header {
+            padding: 16px 20px;
+          }
+
+          .hero {
+            padding: 68px 52px;
+          }
+
+          .final-cta {
+            padding: 40px 36px;
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          html {
+            scroll-behavior: auto;
+          }
+
+          .reveal {
+            animation: none;
+          }
+
+          *,
+          *::before,
+          *::after {
+            transition-duration: 0.01ms !important;
+            animation-duration: 0.01ms !important;
+            animation-iteration-count: 1 !important;
+          }
         }
       `}</style>
-    </AppShell>
+    </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the public homepage with a production-ready, premium dark landing page that positions DEFRAG as a preventive relational intelligence platform focused on natal baseline synthesis, active timing guidance, better pacing, clearer perception, and fewer preventable ruptures.
- Preserve existing repo architecture and keep changes scoped to the homepage while meeting behavior, accessibility, and visual/token requirements.

### Description
- Replaced `apps/web/src/app/page.tsx` with a new mobile-first landing implementation that implements the exact section order and required copy: Header → Hero → Recognition / polarity → What DEFRAG does → How it works → Daily guidance → Baseline design → Long-term value → Final CTA → Footer.
- Wired CTAs and navigation so `Create Account` and `Log In` route to `/login` and `See How It Works` scrolls to `#how-it-works` using in-page anchors and `Link` where appropriate.
- Added restrained dark theme tokens and scoped styles (color tokens, subtle reveal motion, reduced-motion support, visible `:focus-visible`) and semantic headings/sections for accessibility.
- Kept scope limited to the homepage file only and worked on branch `feat/homepage-premium-landing`.

### Testing
- Ran `pnpm typecheck` which completed successfully.
- Ran `pnpm test` which failed due to an existing repo script (`scripts/copy-guard.mjs`) referencing missing `apps/web/src/app/account/insights/page.tsx`, an unrelated pre-existing issue not caused by the homepage change.
- Ran `pnpm build` which failed in this environment because `next/font` could not fetch Google Fonts (`Inter` / `Cormorant_Garamond`), also unrelated to the homepage code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cf0b8b8178833282b0c1a3d2cefa3a)