### PR TITLE
Add Story Canvas package and provider-router; integrate Story Canvas into workspace and polish web copy/fonts

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,250 @@
+# ExecPlan — Defrag Phase 4: Story Canvas foundation
+
+## 1) Context
+- We need an additive, package-local foundation package at `packages/story-canvas` for Defrag’s visual narrative layer.
+- Scope is strictly limited to `packages/story-canvas/**` and `PLANS.md`; no app wiring, no root config changes, and no edits to existing packages.
+- Implementation must mirror existing repo package patterns (TypeScript, pure-function modules, package-local tests).
+- Functional baseline required in this phase:
+  - types for beats, scenes, grammars, lens, annotations
+  - grammar registry with six named grammars
+  - pure builders for scene, beats, annotations, rewrite paths
+  - sample fixture and package-local tests
+- Product policy constraints must be encoded in outputs and tests:
+  - plain-language overlays
+  - constructive, anti-stigma framing
+  - no villain framing, humiliation, manipulation, or exaggerated diagnosis language
+  - default lens support for `plain` and `cinematic`
+
+## 2) Plan
+1. Create `packages/story-canvas` with the exact required folder/file layout and a minimal package manifest with package-local `test` script.
+2. Define strict, composable types in `types/*` for all required domain models.
+3. Add six grammar definitions in `grammars/*` and aggregate them through a registry exported from package root.
+4. Implement deterministic pure builders in `core/*`:
+   - `buildScene` to normalize scene shape and lens defaults
+   - `buildBeats` to derive beats from dynamic input and grammar
+   - `buildAnnotations` to enforce policy-safe overlays
+   - `buildRewrite` to generate constructive rewrite path options
+5. Add `fixtures/sampleDynamic.ts` with representative input.
+6. Add package-local tests for scene construction and grammar registry/constraints.
+7. Run package-local tests via `pnpm --filter @defrag/story-canvas test` and confirm no out-of-scope changes.
+
+## 3) Steps
+1. Scaffold files under `packages/story-canvas` exactly as required.
+2. Add `package.json` and `index.ts` export surface (types, grammars, core builders, fixture).
+3. Implement `types/beats.ts` and `types/scene.ts` with stable IDs, ordering, and constructive framing fields.
+4. Implement `types/grammar.ts` and six grammar modules with deterministic metadata and narrative templates.
+5. Implement `types/lens.ts` with default-safe lens union (`plain` and `cinematic`) and helper defaults.
+6. Implement `types/annotations.ts` including annotation severity/category and rewrite-path models.
+7. Implement `core/buildScene.ts` as a pure constructor applying lens defaults and scene normalization.
+8. Implement `core/buildBeats.ts` to derive ordered beats from fixture-compatible dynamic input plus selected grammar.
+9. Implement `core/buildAnnotations.ts` to produce plain-language, anti-stigma annotations and filter disallowed framing.
+10. Implement `core/buildRewrite.ts` to output constructive rewrite options with deterministic ordering.
+11. Add fixture in `fixtures/sampleDynamic.ts` to support tests.
+12. Write tests:
+    - `scene.test.ts` for lens defaults, deterministic scene/beat output, and constructive constraints.
+    - `grammars.test.ts` for registry integrity (all six grammars) and policy-safe content checks.
+13. Execute package-local tests and ensure git diff only includes allowed paths.
+
+## 4) Validation
+- Command: `pnpm --filter @defrag/story-canvas test`
+- Assertions to verify:
+  - all required files compile and export correctly from `index.ts`
+  - scene builder defaults lens behavior to support `plain` + `cinematic`
+  - grammar registry includes all six required grammars
+  - builders remain pure/deterministic (same input => same output)
+  - annotations and rewrite paths enforce anti-stigma, non-manipulative language constraints
+  - no edits outside `packages/story-canvas/**` and `PLANS.md`
+
+## 5) Recovery
+- If tests fail due type/export mismatches:
+  - reconcile `index.ts` exports first, then align test imports.
+- If policy constraint assertions fail:
+  - tighten annotation/rewrite text generation and grammar copy to remove prohibited framing.
+- If deterministic assertions fail:
+  - remove non-deterministic values (timestamps/randomness) and enforce stable ordering.
+- If package-local test execution fails due config resolution:
+  - add package-local Vitest config inside `packages/story-canvas` only; do not touch root config.
+- If any required fix appears to require out-of-scope changes:
+  - stop implementation and report the exact blocked file and reason before proceeding.
+
+---
+
+# ExecPlan — Phase 5: Web shell hardening
+
+## Context
+- Harden the live `apps/web` shell toward a premium dark mono workspace without changing routes, billing/auth logic, schemas, or package contracts.
+
+## Plan
+1. Refine the primary `/workspace` shell into a clearer left / center / right structure.
+2. Add safe, typed placeholder surfaces for Story Canvas, Dynamics, Practice, and Timeline/Field Weather.
+3. Keep existing interpret workflow and route behavior intact.
+
+## Steps
+1. Update `apps/web/src/app/workspace/page.tsx` styles/layout hierarchy for dark mono shell clarity.
+2. Add right-rail placeholder panels for future integration surfaces.
+3. Keep API calls/transcript behavior unchanged and maintain responsive behavior.
+4. Run `pnpm --dir apps/web typecheck`.
+
+## Validation
+- Workspace route renders with refined shell and placeholders.
+- Existing interaction flow (interpret, transcript, visual field) remains functional.
+- Typecheck passes for `apps/web`.
+
+## Recovery
+- If typecheck fails, revert the smallest shell change causing typing drift and re-run checks.
+- If layout regression appears, preserve current behavior and reduce only the styling delta.
+
+---
+
+# ExecPlan — Phase 6: Story Canvas web integration
+
+## Context
+- Integrate the existing `packages/story-canvas` foundation into `apps/web` so `/workspace` shows a real Story Canvas output panel using live workspace state.
+
+## Plan
+1. Wire `apps/web` workspace route to consume Story Canvas builders (`buildScene`, `buildAnnotations`, `buildRewrite`) from the package.
+2. Derive Story Canvas input from current workspace message/interpret response.
+3. Render a real Story Canvas section with scene title, overlay, ordered beats, annotations, and a constructive rewrite path.
+4. Preserve existing workspace flow and dark mono presentation.
+
+## Steps
+1. Update `apps/web/src/app/workspace/page.tsx` imports and typed memoized Story Canvas data construction.
+2. Replace one placeholder panel with real Story Canvas content while retaining the existing right-rail structure.
+3. Keep remaining placeholders additive and non-destructive.
+4. Run `pnpm --dir apps/web typecheck`.
+
+## Validation
+- `/workspace` compiles with real Story Canvas package usage.
+- Story Canvas panel displays all required fields from live page state.
+- Existing interpret behavior remains unchanged.
+
+## Recovery
+- If type integration fails, align import paths and input shaping without changing route topology.
+- If render density regresses UX, keep data output but reduce visual weight in panel styling.
+
+---
+
+# ExecPlan — Phase 7: Web build reliability (font hardening)
+
+## Context
+- Current `apps/web` production build fails when `next/font/google` cannot fetch font files in restricted/cloud environments.
+
+## Plan
+1. Remove network-dependent Google font imports in `apps/web` layout.
+2. Replace with system-safe font stacks and explicit CSS variables for display/body serif usage.
+3. Preserve dark premium mono styling and existing route behavior.
+4. Validate with typecheck and build.
+
+## Steps
+1. Update `apps/web/src/app/layout.tsx` to remove `next/font/google` usage.
+2. Define local CSS font variables (`--font-display`, `--font-sans`, `--font-cormorant`) with safe fallback stacks.
+3. Keep existing global styles unchanged except font sourcing.
+4. Run `pnpm --dir apps/web typecheck` and `pnpm --dir apps/web build`.
+
+## Validation
+- Web app typecheck passes.
+- Web app build passes without external font fetch failures.
+
+## Recovery
+- If typography regresses visually, tune fallback stacks while keeping them network-independent.
+
+---
+
+# ExecPlan — Phase 8: Deployable web build and env audit
+
+## Context
+- Move `apps/web` to a clean, deployable state by removing build-time fragility and documenting concrete env requirements from real code paths.
+
+## Plan
+1. Audit required env vars from `apps/web` code that can block build/prerender/runtime.
+2. Harden auth-related client routes so missing browser Supabase env does not crash prerender/build.
+3. Keep product copy plain-language and Defrag-branded in touched auth/workflow surfaces.
+4. Run full web typecheck and build to verify green checks.
+
+## Steps
+1. Remove eager Supabase client instantiation from prerendered client pages (`/signin`, `/signup`, `/signin/studio`, `/signup/studio`, `/onboarding`).
+2. Instantiate Supabase client only inside user actions and surface a clear preview-env message if keys are absent.
+3. Keep semantics unchanged for successful configured environments.
+4. Run `pnpm --dir apps/web typecheck` and `pnpm --dir apps/web build`.
+
+## Validation
+- Typecheck passes.
+- Build passes in this environment.
+- Env checklist is extracted from real code paths.
+
+## Recovery
+- If a route still fails prerender due env reads, defer env access to user-triggered handlers or server-only runtime paths without changing route topology.
+
+
+---
+
+# ExecPlan — Phase 9: Product polish pass
+
+## Context
+- Keep the now-green web build state and polish high-traffic product surfaces for clearer Defrag positioning, simpler language, and premium dark consistency.
+
+## Plan
+1. Tighten copy and CTA hierarchy on landing and login/signup surfaces.
+2. Clarify billing/checkout entry messaging without changing billing logic.
+3. Polish natal baseline walkthrough wording in intake.
+4. Refine workspace/Story Canvas entry copy to feel less placeholder-like.
+
+## Validation
+- Run `pnpm --dir apps/web typecheck`
+- Run `pnpm --dir apps/web build`
+
+---
+
+# ExecPlan — Phase 10: Story Canvas intelligence upgrade
+
+## Context
+- Story Canvas is integrated and stable, but current outputs can read templated.
+- We need deeper grammar differentiation and more contextual, product-grade language while preserving deterministic, anti-stigma behavior.
+
+## Plan
+1. Upgrade `packages/story-canvas` builders to inject deterministic, context-aware variation using relationship, friction, goal, and weather inputs.
+2. Improve annotation categorization and rewrite usefulness while keeping non-manipulative, non-diagnostic framing.
+3. Refine workspace Story Canvas panel presentation so richer output is legible and clearly structured.
+
+## Validation
+- Run `pnpm --filter @defrag/story-canvas test`
+- Run `pnpm --dir apps/web typecheck`
+- Run `pnpm --dir apps/web build`
+
+---
+
+# ExecPlan — Phase 11: Journey coherence polish (intake → workspace → billing)
+
+## Context
+- The shell is stable and build-green, but the shipping flow still has wording density and minor continuity gaps between intake, workspace entry, and billing entry.
+
+## Plan
+1. Refine intake walkthrough pacing and labels to reduce form fatigue and make value/steps clearer.
+2. Tighten workspace entry copy so it reads as a direct continuation from baseline intake.
+3. Simplify billing/plan language for faster scan and clearer CTA expectations.
+
+## Validation
+- Run `git status --short`
+- Run `git branch --show-current`
+- Run `git log --oneline -n 5`
+- Run `pnpm --dir apps/web typecheck`
+- Run `pnpm --dir apps/web build`
+
+---
+
+# ExecPlan — Phase 12: Final product completion pass
+
+## Context
+- Core features are implemented and stable; this phase focuses on final UX/copy completion so the full shipped journey feels cohesive and premium.
+
+## Plan
+1. Finalize landing, auth, onboarding, and intake wording for cleaner hierarchy and stronger continuity.
+2. Tighten workspace + Story Canvas first-run guidance and panel labels for immediate comprehension.
+3. Finalize billing entry copy across public/studio/account surfaces for plan clarity and CTA confidence.
+
+## Validation
+- Run `git status --short`
+- Run `git branch --show-current`
+- Run `git log --oneline -n 5`
+- Run `pnpm --dir apps/web typecheck`
+- Run `pnpm --dir apps/web build`

--- a/apps/web/src/app/account/billing/page.tsx
+++ b/apps/web/src/app/account/billing/page.tsx
@@ -10,24 +10,24 @@ const PLANS = [
     key: "base",
     label: "Free",
     price: "Included",
-    description: "An introduction to relational awareness and access to the Defrag workspace.",
-    features: ["workspace access", "basic relational context", "account-linked entry"],
+    description: "An introduction to relational awareness with access to the Defrag workspace.",
+    features: ["Workspace access", "Basic relational context", "Account-linked entry"],
   },
   {
     key: "core",
     label: "Solo",
     price: "$15",
     period: "/ month",
-    description: "Full personal relational intelligence for people who want regular support understanding difficult interactions.",
-    features: ["personal pattern analysis", "1:1 interaction analysis", "structured next-step guidance"],
+    description: "Full personal relational intelligence for regular support through difficult interactions.",
+    features: ["Personal pattern analysis", "1:1 interaction analysis", "Structured next-step guidance"],
   },
   {
     key: "studio",
     label: "Team",
     price: "$45",
     period: "/ month",
-    description: "Relational intelligence across collaborative systems, recurring pressure, and broader multi-person dynamics.",
-    features: ["multi-person system analysis", "perspective comparison", "broader team and family dynamics"],
+    description: "Relational intelligence across collaborative systems and recurring multi-person dynamics.",
+    features: ["Multi-person system analysis", "Perspective comparison", "Broader team and family dynamics"],
   },
 ];
 
@@ -38,8 +38,8 @@ export default async function BillingPage() {
     return (
       <AppShell
         eyebrow="Plans"
-        title="Choose the level of access that fits how you want to use Defrag."
-        description="Start with the workspace you need today. You can change your plan later."
+        title="Choose the Defrag access level that fits your workflow."
+        description="Start with what you need now. You can change plans anytime."
       >
         <div style={{ maxWidth: 1160, display: "grid", gap: 56 }}>
           <section style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 320px", gap: 40 }} className="billing-top-grid">
@@ -48,10 +48,10 @@ export default async function BillingPage() {
                 Access and billing
               </div>
               <h2 className="font-display" style={{ margin: 0, fontSize: "clamp(2.3rem, 5vw, 4rem)", lineHeight: 0.96, color: "white" }}>
-                Sign in to choose a plan.
+                Sign in to choose your plan.
               </h2>
               <p style={{ margin: 0, fontSize: 16, color: "rgba(245,245,245,0.62)", lineHeight: 1.78, fontWeight: 300 }}>
-                Your account keeps your workspace, saved context, and paid access in one place. Sign in to continue to checkout.
+                Your account keeps your workspace, saved context, and paid access in one place. Sign in to continue to checkout and plan management.
               </p>
             </div>
 
@@ -63,7 +63,7 @@ export default async function BillingPage() {
                 Use your Defrag account to choose a plan and manage billing in one place.
               </p>
               <Link href="/login" style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 10, width: "fit-content", padding: "16px 28px", borderRadius: 14, background: "white", color: "#050505", textDecoration: "none", fontWeight: 600, fontSize: 16 }}>
-                Sign in <ArrowRight style={{ width: 18, height: 18 }} />
+                Sign in to continue <ArrowRight style={{ width: 18, height: 18 }} />
               </Link>
             </div>
           </section>
@@ -129,9 +129,9 @@ function PlanBreakdown({ activePlanKey }: { activePlanKey: string | null }) {
   return (
     <div style={{ display: "grid", gap: 28 }}>
       <div style={{ display: "grid", gap: 10, maxWidth: 760 }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245,245,245,0.38)" }}>Access tiers</div>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245,245,245,0.38)" }}>Plan tiers</div>
         <p style={{ margin: 0, fontSize: 16, lineHeight: 1.75, color: "rgba(245,245,245,0.58)" }}>
-          Defrag is structured as an intelligence tier system. Choose the level that matches the depth of analysis and ongoing support you need.
+          Choose the level of support you need now. Upgrade any time when your workflow needs more depth.
         </p>
       </div>
 

--- a/apps/web/src/app/billing/page.tsx
+++ b/apps/web/src/app/billing/page.tsx
@@ -9,21 +9,21 @@ const PLANS: Array<{ id: PlanId; name: string; price: string; summary: string; p
     id: "core",
     name: "Core",
     price: "$24/mo",
-    summary: "The main DEFRAG workspace and baseline flow.",
+    summary: "Best for one person starting with baseline + workspace.",
     points: ["Baseline intake", "Relationship workspace", "Mobile workspace"],
   },
   {
     id: "studio",
     name: "Studio",
     price: "$72/mo",
-    summary: "More room for guided sessions and family work.",
+    summary: "Best for recurring family or team patterns.",
     points: ["Everything in Core", "Deeper family layering", "Longer guided sessions"],
   },
   {
     id: "realtime",
     name: "Realtime",
     price: "$149/mo",
-    summary: "The highest tier for the fastest product iteration path.",
+    summary: "Best for intensive ongoing support and priority access.",
     points: ["Everything in Studio", "Priority workspace access", "Future realtime features"],
   },
 ];
@@ -80,13 +80,13 @@ export default function BillingPage() {
       <section style={{ maxWidth: 1240, margin: "0 auto", display: "grid", gap: 24 }}>
         <div style={{ display: "grid", gap: 8, border: "1px solid rgba(255,255,255,0.08)", background: "linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015))", padding: 24 }}>
           <div style={{ fontSize: 11, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245,242,236,0.42)" }}>Billing</div>
-          <h1 style={{ margin: 0, fontSize: 52, lineHeight: 0.96, fontFamily: "var(--font-display), serif" }}>Choose your DEFRAG plan</h1>
+          <h1 style={{ margin: 0, fontSize: 52, lineHeight: 0.96, fontFamily: "var(--font-display), serif" }}>Choose your Defrag plan</h1>
           <div style={{ color: "rgba(245,242,236,0.62)", maxWidth: 760, lineHeight: 1.72 }}>
-            This page uses the live Stripe checkout and billing portal routes added to the branch. Sign in first, then choose a plan or open the portal.
+            Choose the plan that fits your workflow, then use billing portal access any time to manage your subscription.
           </div>
           <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
             <button onClick={openPortal} disabled={portalLoading} style={{ border: 0, padding: "13px 16px", background: "#f5f2ec", color: "#050505", fontWeight: 700 }}>
-              {portalLoading ? "Opening portal..." : "Open billing portal"}
+              {portalLoading ? "Opening portal..." : "Manage billing"}
             </button>
           </div>
           {error ? <div style={{ color: "#fca5a5" }}>{error}</div> : null}
@@ -106,7 +106,7 @@ export default function BillingPage() {
                 ))}
               </div>
               <button onClick={() => startCheckout(plan.id)} disabled={loadingPlan === plan.id} style={{ border: 0, padding: "13px 16px", background: "#f5f2ec", color: "#050505", fontWeight: 700 }}>
-                {loadingPlan === plan.id ? "Opening checkout..." : `Choose ${plan.name}`}
+                {loadingPlan === plan.id ? "Opening checkout..." : `Start ${plan.name}`}
               </button>
             </article>
           ))}

--- a/apps/web/src/app/billing/studio/page.tsx
+++ b/apps/web/src/app/billing/studio/page.tsx
@@ -9,21 +9,21 @@ const PLANS: Array<{ id: PlanId; name: string; price: string; summary: string; p
     id: 'core',
     name: 'Core',
     price: '$24/mo',
-    summary: 'The main DEFRAG workspace and baseline flow.',
+    summary: 'Best for one person using baseline and workspace tools.',
     points: ['Baseline intake', 'Relationship workspace', 'Mobile workspace'],
   },
   {
     id: 'studio',
     name: 'Studio',
     price: '$72/mo',
-    summary: 'More room for guided sessions and family work.',
+    summary: 'Best for recurring family or team dynamics.',
     points: ['Everything in Core', 'Deeper family layering', 'Longer guided sessions'],
   },
   {
     id: 'realtime',
     name: 'Realtime',
     price: '$149/mo',
-    summary: 'The highest tier for the fastest product iteration path.',
+    summary: 'Best for high-touch ongoing support and priority access.',
     points: ['Everything in Studio', 'Priority workspace access', 'Future realtime features'],
   },
 ];
@@ -104,9 +104,9 @@ export default function StudioBillingPage() {
         <section className='bill-hero'>
           <div className='bill-card bill-overview'>
             <div className='bill-kicker'>Premium plans</div>
-            <h1 className='bill-title'>Choose your DEFRAG studio plan.</h1>
+            <h1 className='bill-title'>Choose your Defrag studio plan.</h1>
             <div className='bill-muted' style={{ lineHeight: 1.78, fontSize: 18 }}>
-              Pick the level that fits how deeply you want to use DEFRAG. This page is wired to the live Stripe checkout and billing portal routes already in the branch.
+              Pick the level that fits how you want to use Defrag. Checkout and billing portal access are live on this page.
             </div>
             <div className='bill-actions'>
               <button className='bill-btn primary' onClick={openPortal} disabled={portalLoading}>{portalLoading ? 'Opening portal...' : 'Open billing portal'}</button>
@@ -146,7 +146,7 @@ export default function StudioBillingPage() {
                 ))}
               </div>
               <button className='bill-btn primary' onClick={() => startCheckout(plan.id)} disabled={loadingPlan === plan.id}>
-                {loadingPlan === plan.id ? 'Opening checkout...' : `Choose ${plan.name}`}
+                {loadingPlan === plan.id ? 'Opening checkout...' : `Start ${plan.name}`}
               </button>
             </article>
           ))}

--- a/apps/web/src/app/intake/page.tsx
+++ b/apps/web/src/app/intake/page.tsx
@@ -70,8 +70,10 @@ export default function IntakePage() {
         .intake-grid { display: grid; grid-template-columns: 1.02fr 0.98fr; gap: 22px; }
         .intake-card { border: 1px solid rgba(255,255,255,0.08); background: linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.015)); box-shadow: 0 16px 40px rgba(0,0,0,0.18); }
         .intake-copy { padding: 28px; display: grid; gap: 18px; align-content: start; }
+        .intake-phase { display: flex; gap: 8px; flex-wrap: wrap; }
         .intake-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
         .intake-muted { color: rgba(245,242,236,0.64); }
+        .intake-chip { display: inline-flex; align-items: center; gap: 6px; padding: 8px 10px; border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.02); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(245,242,236,0.62); }
         .intake-title { margin: 0; font-size: 64px; line-height: 0.92; letter-spacing: -0.04em; font-family: var(--font-display), serif; }
         .intake-stage { position: relative; overflow: hidden; min-height: 620px; }
         .intake-stage::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 22% 18%, rgba(255,255,255,0.06), transparent 24%), radial-gradient(circle at 72% 22%, rgba(214,195,161,0.10), transparent 28%), radial-gradient(circle at 66% 76%, rgba(255,255,255,0.04), transparent 24%); }
@@ -110,7 +112,7 @@ export default function IntakePage() {
             <div className='intake-mark' />
             <div style={{ display: 'grid', gap: 4 }}>
               <div className='intake-kicker'>Defrag</div>
-              <div>Baseline intake</div>
+              <div>Natal baseline walkthrough</div>
             </div>
           </div>
           <nav className='intake-nav'>
@@ -122,13 +124,18 @@ export default function IntakePage() {
 
         <section className='intake-grid'>
           <section className='intake-card intake-copy'>
-            <div className='intake-kicker'>Begin here</div>
-            <h1 className='intake-title'>Start with the details that shape your baseline.</h1>
+            <div className='intake-kicker'>Guided intake</div>
+            <h1 className='intake-title'>Create your natal baseline in three short steps.</h1>
+            <div className='intake-phase'>
+              <span className='intake-chip'>Step 1 · Core birth details</span>
+              <span className='intake-chip'>Step 2 · Current context</span>
+              <span className='intake-chip'>Step 3 · Preview + workspace</span>
+            </div>
             <div className='intake-muted' style={{ fontSize: 18, lineHeight: 1.78 }}>
-              DEFRAG turns the basics of your profile into simple language you can actually use.
+              Defrag uses these details to create a clear baseline you can carry into the workspace.
             </div>
             <div className='intake-muted' style={{ lineHeight: 1.78 }}>
-              Fill in the core details below, generate a preview, and then carry that into the relationship workspace.
+              You only need your date of birth to start. Add time, place, and context when available for a fuller baseline.
             </div>
 
             <div className='intake-formgrid'>
@@ -155,15 +162,18 @@ export default function IntakePage() {
             </div>
 
             <label className='intake-field'>
-              <span className='intake-kicker'>What you want help with</span>
+              <span className='intake-kicker'>Relationship context</span>
               <textarea className='intake-input intake-textarea' value={form.context} onChange={(e) => setForm({ ...form, context: e.target.value })} />
             </label>
+            <div className='intake-muted' style={{ fontSize: 13, lineHeight: 1.68 }}>
+              This note helps Defrag frame your baseline around the moment you want to understand.
+            </div>
 
             <div className='intake-btnrow'>
               <button className='intake-btn' onClick={generatePreview} disabled={!ready || loading}>
-                {loading ? 'Generating preview...' : 'Generate preview'}
+                {loading ? 'Creating preview...' : 'Create baseline preview'}
               </button>
-              <a className='intake-btn secondary' href='/workspace'>Open workspace</a>
+              <a className='intake-btn secondary' href='/workspace'>Go to workspace</a>
             </div>
           </section>
 
@@ -173,9 +183,9 @@ export default function IntakePage() {
             <div className='intake-previewbox'>
               <div className='intake-kicker'>What you will get</div>
               <div className='intake-stepgrid'>
-                <div className='intake-step'>A first read on how you may react and relate.</div>
-                <div className='intake-step'>A simple summary you can carry into the workspace.</div>
-                <div className='intake-step'>One clear next step to start with.</div>
+                <div className='intake-step'>A plain-language read of your core pattern.</div>
+                <div className='intake-step'>A short summary you can bring into workspace analysis.</div>
+                <div className='intake-step'>One grounded next step you can try right away.</div>
               </div>
             </div>
 
@@ -203,7 +213,7 @@ export default function IntakePage() {
                 </>
               ) : (
                 <div className='intake-muted' style={{ lineHeight: 1.74 }}>
-                  Generate a preview to see your first plain-language baseline here before moving into the workspace.
+                  Create a preview to see your natal baseline before you move into the workspace.
                 </div>
               )}
               {result?.warning ? <div className='intake-step'>{result.warning}</div> : null}

--- a/apps/web/src/app/landing/page.tsx
+++ b/apps/web/src/app/landing/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 const STEPS = [
   {
     label: "Start with your baseline",
-    body: "Enter the core birth details that help DEFRAG translate how you tend to react, cope, and relate into simple language.",
+    body: "Share a few core birth details so Defrag can build a clear baseline in plain language.",
   },
   {
     label: "See the relationship more clearly",
@@ -11,7 +11,7 @@ const STEPS = [
   },
   {
     label: "Move toward a healthier next step",
-    body: "Use the guided thread, visual field, and focused views to choose what may help next.",
+    body: "Use guided views to choose one practical next step that lowers pressure.",
   },
 ];
 
@@ -74,17 +74,17 @@ export default function LandingPage() {
         <section className="land-hero">
           <div className="land-card" style={{ padding: 26, display: "grid", gap: 20, alignContent: "start" }}>
             <div className="land-kicker">Defrag</div>
-            <div className="land-title">See what is happening between people.</div>
+            <div className="land-title">Read relationship moments with more clarity.</div>
             <div className="land-muted" style={{ maxWidth: 700, lineHeight: 1.76, fontSize: 18 }}>
-              DEFRAG helps people understand hard relationship patterns in simple language, so they can respond in a healthier way.
+              Defrag turns tense interactions into clear language so you can respond with more steadiness.
             </div>
             <div className="land-muted" style={{ maxWidth: 700, lineHeight: 1.72 }}>
-              Start with your baseline. Then bring that into a live workspace that helps you see what may be happening, what each person may be carrying, and what could help next.
+              Start with your baseline, then move into workspace analysis to see the pattern, compare perspectives, and choose your next move.
             </div>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-              <Link className="land-btn primary" href="/start">Start here</Link>
-              <Link className="land-btn secondary" href="/workspace/final">Open the workspace</Link>
-              <Link className="land-btn secondary" href="/membership">View membership</Link>
+              <Link className="land-btn primary" href="/start">Start your baseline</Link>
+              <Link className="land-btn secondary" href="/workspace/final">Try workspace</Link>
+              <Link className="land-btn secondary" href="/membership">View plans</Link>
             </div>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
               <span className="land-chip">Simple language</span>
@@ -119,7 +119,7 @@ export default function LandingPage() {
 
             <div className="land-summary">
               <div className="land-card" style={{ padding: 16, display: "grid", gap: 10 }}>
-                <div className="land-kicker">Live workspace preview</div>
+                <div className="land-kicker">Workspace preview</div>
                 <div style={{ fontSize: 24, fontFamily: "var(--font-display), serif" }}>What may be happening</div>
                 <div className="land-muted" style={{ lineHeight: 1.7 }}>
                   Both people may care about the relationship, but may be reacting in ways that make each other harder to hear.

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,22 +1,5 @@
 import type { Metadata } from 'next';
-import { Fraunces, Inter, Cormorant_Garamond } from 'next/font/google';
 import type { ReactNode } from 'react';
-
-const fraunces = Fraunces({
-  subsets: ['latin'],
-  variable: '--font-display',
-});
-
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-sans',
-});
-
-const cormorant = Cormorant_Garamond({
-  subsets: ['latin'],
-  weight: ['300', '400', '500', '600', '700'],
-  variable: '--font-cormorant',
-});
 
 export const metadata: Metadata = {
   title: 'DEFRAG',
@@ -33,17 +16,20 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en'>
       <body
-        className={`${inter.variable} ${cormorant.variable}`}
         style={{
           margin: 0,
           background: '#040404',
           color: '#f5f5f5',
-          fontFamily: 'var(--font-sans), sans-serif',
+          fontFamily:
+            'var(--font-sans), Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif',
         }}
       >
         <style>{`
           :root {
             color-scheme: dark;
+            --font-display: "Fraunces", "Times New Roman", Georgia, serif;
+            --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            --font-cormorant: "Cormorant Garamond", "Times New Roman", Georgia, serif;
             --color-bg: #050505;
             --color-surface: rgba(255, 255, 255, 0.03);
             --color-surface-hover: rgba(255, 255, 255, 0.05);

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -40,21 +40,21 @@ function LoginContent(): React.JSX.Element {
             <div style={{ position: "absolute", inset: 0, background: "radial-gradient(circle at 10% 12%, rgba(159,179,164,0.22), transparent 18%), radial-gradient(circle at 82% 18%, rgba(255,255,255,0.08), transparent 14%)" }} />
             <div style={{ position: "relative", display: "grid", gap: 18, alignContent: "start", maxWidth: 760 }}>
               <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.22em", textTransform: "uppercase", color: "rgba(245,245,245,0.42)" }}>
-                Relational Intelligence Infrastructure
+                Defrag
               </div>
               <h1 className="font-display" style={{ margin: 0, fontSize: "clamp(4rem, 8vw, 7.2rem)", lineHeight: 0.84, color: "white" }}>
-                Open the workspace and read the moment clearly.
+                Open Defrag and steady the moment.
               </h1>
               <p style={{ margin: 0, maxWidth: 620, fontSize: 17, lineHeight: 1.84, color: "rgba(245,245,245,0.66)" }}>
-                Use Defrag to understand difficult interactions, compare perspectives across sides, and receive structured guidance on what may be happening and what to do next.
+                Use Defrag to read difficult interactions, compare perspectives, and choose one clear next step.
               </p>
             </div>
 
             <div style={{ position: "relative", display: "grid", gap: 14, maxWidth: 760 }}>
               {[
-                "Read what may be happening beneath the interaction.",
+                "See what may be happening beneath the interaction.",
                 "Compare how each side may be reading the moment.",
-                "Choose a next move that lowers pressure instead of adding more distortion.",
+                "Choose a next move that lowers pressure.",
               ].map((line, index) => (
                 <div key={line} style={{ width: `${92 - index * 10}%`, marginLeft: index === 2 ? "auto" : 0, padding: "16px 18px", borderLeft: "1px solid rgba(255,255,255,0.16)", background: "rgba(255,255,255,0.03)", boxShadow: "0 22px 48px rgba(0,0,0,0.26)", fontSize: 15, lineHeight: 1.72, color: "rgba(245,245,245,0.92)" }}>
                   {line}
@@ -72,7 +72,7 @@ function LoginContent(): React.JSX.Element {
                 Enter Defrag
               </h2>
               <p style={{ margin: 0, fontSize: 14, lineHeight: 1.72, color: "rgba(245,245,245,0.58)" }}>
-                Enter your email and we will send a secure link so you can continue directly to your workspace.
+                Enter your email and we’ll send a secure link to continue.
               </p>
             </div>
 
@@ -80,7 +80,7 @@ function LoginContent(): React.JSX.Element {
               <div style={{ display: "grid", gap: 12, padding: 20, border: "1px solid rgba(255,255,255,0.08)", background: "rgba(255,255,255,0.02)" }}>
                 <div style={{ display: "flex", alignItems: "center", gap: 8, color: "#c8d8a2", fontSize: 14, fontWeight: 600 }}>
                   <CheckCircle2 style={{ width: 16, height: 16 }} />
-                  Link sent
+                  Secure link sent
                 </div>
                 <p style={{ fontSize: 14, color: "rgba(245,245,245,0.62)", margin: 0, lineHeight: 1.6 }}>
                   Check your email and follow the link to continue.

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -6,10 +6,12 @@ import { AppShell } from "@/components/app-shell";
 import { createClient } from "@/utils/supabase/client";
 import { ArrowRight, User } from "lucide-react";
 
+const PREVIEW_ENV_ERROR =
+  "Onboarding is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.";
+
 function OnboardingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const supabase = createClient();
 
   const [displayName, setDisplayName] = useState("");
   const [busy, setBusy] = useState(false);
@@ -22,7 +24,7 @@ function OnboardingContent() {
   const title = "Finish setting up your account.";
   const description = isInviteFlow
     ? "Before you open the shared summary, add your name so we can finish your setup."
-    : "Add your name to continue to your workspace.";
+    : "Add your name to continue to your Defrag workspace.";
 
   return (
     <AppShell
@@ -63,6 +65,16 @@ function OnboardingContent() {
               onClick={async () => {
                 setBusy(true);
                 setError(null);
+
+                let supabase;
+                try {
+                  supabase = createClient();
+                } catch {
+                  setError(PREVIEW_ENV_ERROR);
+                  setBusy(false);
+                  return;
+                }
+
                 try {
                   const {
                     data: { user },
@@ -114,7 +126,7 @@ function OnboardingContent() {
             </button>
 
             <p style={{ margin: 0, fontSize: 13, color: "rgba(245, 245, 245, 0.44)", lineHeight: 1.6, maxWidth: 440 }}>
-              Your account helps keep your workspace available when you come back. You stay in control of what you keep and share.
+              Your account keeps your workspace ready when you come back. You stay in control of what you keep and share.
             </p>
           </div>
 

--- a/apps/web/src/app/signin/page.tsx
+++ b/apps/web/src/app/signin/page.tsx
@@ -5,9 +5,11 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/utils/supabase/client";
 
+const PREVIEW_ENV_ERROR =
+  "Sign in is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.";
+
 export default function SignInPage() {
   const router = useRouter();
-  const supabase = createClient();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -17,6 +19,15 @@ export default function SignInPage() {
     event.preventDefault();
     setLoading(true);
     setError(null);
+
+    let supabase;
+    try {
+      supabase = createClient();
+    } catch {
+      setError(PREVIEW_ENV_ERROR);
+      setLoading(false);
+      return;
+    }
 
     const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
 
@@ -35,9 +46,9 @@ export default function SignInPage() {
       <section style={{ width: "min(880px, 100%)", display: "grid", gridTemplateColumns: "1.05fr 0.95fr", gap: 20 }}>
         <div style={{ border: "1px solid rgba(255,255,255,0.08)", background: "linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015))", padding: 28, display: "grid", gap: 18 }}>
           <div style={{ fontSize: 11, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245,242,236,0.42)" }}>Sign in</div>
-          <h1 style={{ margin: 0, fontSize: 54, lineHeight: 0.94, fontFamily: "var(--font-display), serif" }}>Return to your DEFRAG workspace.</h1>
+          <h1 style={{ margin: 0, fontSize: 54, lineHeight: 0.94, fontFamily: "var(--font-display), serif" }}>Return to your Defrag workspace.</h1>
           <p style={{ margin: 0, color: "rgba(245,242,236,0.62)", lineHeight: 1.74 }}>
-            Sign in to continue your baseline, open the relationship workspace, and manage billing from one account.
+            Sign in to continue your baseline, open workspace analysis, and manage billing from one account.
           </p>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 10 }}>
             {[
@@ -60,9 +71,9 @@ export default function SignInPage() {
           </div>
           <input value={email} onChange={(e) => setEmail(e.target.value)} type="email" placeholder="Email" required style={{ padding: "14px 16px", background: "#0a0a0a", color: "#f5f2ec", border: "1px solid rgba(255,255,255,0.1)" }} />
           <input value={password} onChange={(e) => setPassword(e.target.value)} type="password" placeholder="Password" required style={{ padding: "14px 16px", background: "#0a0a0a", color: "#f5f2ec", border: "1px solid rgba(255,255,255,0.1)" }} />
-          {error ? <div style={{ color: "#fca5a5" }}>{error}</div> : null}
+          {error ? <div style={{ color: "#fca5a5", lineHeight: 1.6 }}>{error}</div> : null}
           <button type="submit" disabled={loading} style={{ border: 0, padding: "14px 18px", background: "#f5f2ec", color: "#050505", fontWeight: 700 }}>
-            {loading ? "Signing in..." : "Continue"}
+            {loading ? "Signing in..." : "Continue to workspace"}
           </button>
           <div style={{ color: "rgba(245,242,236,0.62)", lineHeight: 1.7 }}>
             Need an account? <Link href="/signup" style={{ color: "#f5f2ec" }}>Create one</Link>

--- a/apps/web/src/app/signin/studio/page.tsx
+++ b/apps/web/src/app/signin/studio/page.tsx
@@ -5,9 +5,11 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/utils/supabase/client';
 
+const PREVIEW_ENV_ERROR =
+  'Sign in is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.';
+
 export default function StudioSignInPage() {
   const router = useRouter();
-  const supabase = createClient();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -17,6 +19,15 @@ export default function StudioSignInPage() {
     event.preventDefault();
     setLoading(true);
     setError(null);
+
+    let supabase;
+    try {
+      supabase = createClient();
+    } catch {
+      setError(PREVIEW_ENV_ERROR);
+      setLoading(false);
+      return;
+    }
 
     const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
 
@@ -52,9 +63,9 @@ export default function StudioSignInPage() {
       <section className='signin-shell'>
         <div className='signin-card signin-stage'>
           <div className='signin-kicker'>Premium access</div>
-          <h1 className='signin-title'>Return to your DEFRAG studio.</h1>
+          <h1 className='signin-title'>Return to your Defrag studio.</h1>
           <div className='signin-muted' style={{ lineHeight: 1.76, maxWidth: 560 }}>
-            Sign in to continue your baseline, open the relationship workspace, and manage billing from one account.
+            Sign in to continue your baseline, open workspace analysis, and manage billing in one place.
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0,1fr))', gap: 12 }}>
             <div className='signin-step'>Baseline intake and profile</div>
@@ -66,7 +77,7 @@ export default function StudioSignInPage() {
               <div>
                 <div className='signin-kicker' style={{ fontSize: 10 }}>Defrag</div>
                 <div style={{ fontSize: 30, fontFamily: 'var(--font-display), serif' }}>Studio</div>
-                <div className='signin-muted' style={{ fontSize: 13 }}>premium workspace</div>
+                <div className='signin-muted' style={{ fontSize: 13 }}>premium workflow</div>
               </div>
             </div>
           </div>
@@ -76,11 +87,11 @@ export default function StudioSignInPage() {
           <div style={{ display: 'grid', gap: 8 }}>
             <div className='signin-kicker'>Access</div>
             <div style={{ fontSize: 36, fontFamily: 'var(--font-display), serif' }}>Sign in</div>
-            <div className='signin-muted' style={{ lineHeight: 1.72 }}>Use your DEFRAG account to continue into the upgraded product flow.</div>
+            <div className='signin-muted' style={{ lineHeight: 1.72 }}>Use your Defrag account to continue into your studio workspace and billing flow.</div>
           </div>
           <input className='signin-input' value={email} onChange={(e) => setEmail(e.target.value)} type='email' placeholder='Email' required />
           <input className='signin-input' value={password} onChange={(e) => setPassword(e.target.value)} type='password' placeholder='Password' required />
-          {error ? <div style={{ color: '#fca5a5' }}>{error}</div> : null}
+          {error ? <div style={{ color: '#fca5a5', lineHeight: 1.6 }}>{error}</div> : null}
           <button type='submit' disabled={loading} className='signin-btn'>{loading ? 'Signing in...' : 'Continue to studio'}</button>
           <div className='signin-muted' style={{ lineHeight: 1.7 }}>
             Need an account? <Link href='/signup' style={{ color: '#f5f2ec' }}>Create one</Link>

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -5,9 +5,11 @@ import { FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/utils/supabase/client";
 
+const PREVIEW_ENV_ERROR =
+  "Account creation is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.";
+
 export default function SignUpPage() {
   const router = useRouter();
-  const supabase = createClient();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -27,6 +29,15 @@ export default function SignUpPage() {
 
     if (password !== confirmPassword) {
       setError("Passwords do not match.");
+      setLoading(false);
+      return;
+    }
+
+    let supabase;
+    try {
+      supabase = createClient();
+    } catch {
+      setError(PREVIEW_ENV_ERROR);
       setLoading(false);
       return;
     }
@@ -54,9 +65,9 @@ export default function SignUpPage() {
       <section style={{ width: "min(760px, 100%)", display: "grid", gap: 18, border: "1px solid rgba(255,255,255,0.08)", background: "linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015))", padding: 28 }}>
         <div style={{ display: "grid", gap: 8 }}>
           <div style={{ fontSize: 11, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245,242,236,0.42)" }}>Create account</div>
-          <h1 style={{ margin: 0, fontSize: 44, lineHeight: 0.98, fontFamily: "var(--font-display), serif" }}>Create your DEFRAG account</h1>
+          <h1 style={{ margin: 0, fontSize: 44, lineHeight: 0.98, fontFamily: "var(--font-display), serif" }}>Create your Defrag account</h1>
           <p style={{ margin: 0, color: "rgba(245,242,236,0.62)", lineHeight: 1.72 }}>
-            Create an account first so your baseline, workspace access, and billing state can stay attached to one profile.
+            Create one account so your baseline, workspace access, and billing stay connected.
           </p>
         </div>
 
@@ -64,7 +75,7 @@ export default function SignUpPage() {
           <input value={email} onChange={(e) => setEmail(e.target.value)} type="email" placeholder="Email" required style={{ padding: "14px 16px", background: "#0a0a0a", color: "#f5f2ec", border: "1px solid rgba(255,255,255,0.1)" }} />
           <input value={password} onChange={(e) => setPassword(e.target.value)} type="password" placeholder="Password" required style={{ padding: "14px 16px", background: "#0a0a0a", color: "#f5f2ec", border: "1px solid rgba(255,255,255,0.1)" }} />
           <input value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} type="password" placeholder="Confirm password" required style={{ padding: "14px 16px", background: "#0a0a0a", color: "#f5f2ec", border: "1px solid rgba(255,255,255,0.1)" }} />
-          {error ? <div style={{ color: "#fca5a5" }}>{error}</div> : null}
+          {error ? <div style={{ color: "#fca5a5", lineHeight: 1.6 }}>{error}</div> : null}
           <button type="submit" disabled={loading} style={{ border: 0, padding: "14px 18px", background: "#f5f2ec", color: "#050505", fontWeight: 700 }}>
             {loading ? "Creating account..." : "Create account"}
           </button>

--- a/apps/web/src/app/signup/studio/page.tsx
+++ b/apps/web/src/app/signup/studio/page.tsx
@@ -5,9 +5,11 @@ import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/utils/supabase/client';
 
+const PREVIEW_ENV_ERROR =
+  'Account creation is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.';
+
 export default function StudioSignUpPage() {
   const router = useRouter();
-  const supabase = createClient();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -27,6 +29,15 @@ export default function StudioSignUpPage() {
 
     if (password !== confirmPassword) {
       setError('Passwords do not match.');
+      setLoading(false);
+      return;
+    }
+
+    let supabase;
+    try {
+      supabase = createClient();
+    } catch {
+      setError(PREVIEW_ENV_ERROR);
       setLoading(false);
       return;
     }
@@ -70,14 +81,14 @@ export default function StudioSignUpPage() {
       <section className='signup-shell'>
         <div className='signup-card signup-stage'>
           <div className='signup-kicker'>Create account</div>
-          <h1 className='signup-title'>Create your DEFRAG studio account.</h1>
+          <h1 className='signup-title'>Create your Defrag studio account.</h1>
           <div className='signup-muted' style={{ lineHeight: 1.78 }}>
-            Create one account so your baseline, workspace access, and billing state stay attached to the same premium product flow.
+            Create one account so baseline, workspace access, and billing stay connected in one premium flow.
           </div>
           <div style={{ display: 'grid', gap: 10 }}>
             <div className='signup-step'>One account for baseline, workspace, and billing</div>
-            <div className='signup-step'>Premium studio surfaces across public and signed-in flow</div>
-            <div className='signup-step'>Ready for end-to-end testing on the preview branch</div>
+            <div className='signup-step'>Premium studio surfaces across public and signed-in pages</div>
+            <div className='signup-step'>Built for ongoing use across intake, workspace, and account tools</div>
           </div>
         </div>
 
@@ -89,7 +100,7 @@ export default function StudioSignUpPage() {
           <input className='signup-input' value={email} onChange={(e) => setEmail(e.target.value)} type='email' placeholder='Email' required />
           <input className='signup-input' value={password} onChange={(e) => setPassword(e.target.value)} type='password' placeholder='Password' required />
           <input className='signup-input' value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} type='password' placeholder='Confirm password' required />
-          {error ? <div style={{ color: '#fca5a5' }}>{error}</div> : null}
+          {error ? <div style={{ color: '#fca5a5', lineHeight: 1.6 }}>{error}</div> : null}
           <button type='submit' disabled={loading} className='signup-btn'>{loading ? 'Creating account...' : 'Create account'}</button>
           <div className='signup-muted' style={{ lineHeight: 1.7 }}>
             Already have an account? <Link href='/signin/studio' style={{ color: '#f5f2ec' }}>Sign in</Link>

--- a/apps/web/src/app/workspace/page.tsx
+++ b/apps/web/src/app/workspace/page.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import {
+  buildAnnotations,
+  buildRewrite,
+  buildScene,
+  royalHierarchyGrammar,
+  type Annotation,
+  type RewritePath,
+  type StoryCanvasScene,
+} from "../../../../../packages/story-canvas/index";
 
 type WorkspaceResponse = {
   assistant_message: {
@@ -71,6 +80,20 @@ type WorkspaceResponse = {
   };
 };
 
+type ProductRailCard = {
+  id: "dynamics" | "practice" | "timeline-weather";
+  title: string;
+  subtitle: string;
+  body: string;
+  state: string;
+};
+
+type StoryCanvasView = {
+  scene: StoryCanvasScene;
+  annotations: Annotation[];
+  rewritePath: RewritePath | null;
+};
+
 const INITIAL_MESSAGE =
   "I want to talk to my mom tonight, but I think we may end up missing each other again.";
 
@@ -86,6 +109,65 @@ export default function WorkspacePage() {
       { role: "assistant", body: result.assistant_message.body },
     ];
   }, [message, result]);
+
+  const storyCanvas = useMemo<StoryCanvasView>(() => {
+    const relationshipLabel =
+      result?.field_update.participants.map((participant) => participant.name).join(" and ") || "You and your mother";
+
+    const sharedGoal =
+      result?.assistant_message.next_steps[0] ??
+      "move the conversation toward clarity, steadiness, and a practical next step";
+
+    const scene = buildScene(
+      {
+        relationshipLabel,
+        frictionPoint: message,
+        sharedGoal,
+        emotionalWeather:
+          result?.field_update.field_state.overall_state ?? "both people may care deeply and feel pressure at the same time",
+      },
+      royalHierarchyGrammar,
+      { lens: "plain" },
+    );
+
+    const annotations = buildAnnotations(scene);
+    const rewritePath = buildRewrite(scene, annotations)[0] ?? null;
+
+    return {
+      scene,
+      annotations,
+      rewritePath,
+    };
+  }, [message, result]);
+
+  const placeholderPanels = useMemo<ProductRailCard[]>(() => {
+    const readiness = Math.round((result?.field_update.field_state.readiness_for_repair ?? 0.42) * 100);
+    const weather = result?.field_update.field_state.overall_state ?? "Field weather appears after your first read";
+
+    return [
+      {
+        id: "dynamics",
+        title: "Dynamics read",
+        subtitle: "interaction map",
+        state: "live-linked summary",
+        body: `Current repair readiness is ${readiness}%. This panel tracks sequence-level pressure shifts in plain language.`,
+      },
+      {
+        id: "practice",
+        title: "Practice prompts",
+        subtitle: "conversation rehearsal",
+        state: "guided mode",
+        body: "Use this area for low-pressure wording practice before you send a message.",
+      },
+      {
+        id: "timeline-weather",
+        title: "Timeline and field weather",
+        subtitle: "sequence and climate",
+        state: "session overview",
+        body: `Field weather summary: ${weather}. Use this to track how tone and pressure change across the conversation.`,
+      },
+    ];
+  }, [result]);
 
   async function interpret() {
     setLoading(true);
@@ -111,140 +193,154 @@ export default function WorkspacePage() {
   return (
     <main style={{ minHeight: "100vh", background: "#050505", color: "#f6f3ee" }}>
       <style>{`
-        .defrag-shell { display:grid; grid-template-columns: 360px minmax(0,1fr) 320px; min-height:100vh; }
-        .defrag-panel { border-right:1px solid rgba(255,255,255,0.08); }
-        .defrag-panel:last-child { border-right:none; }
-        .defrag-muted { color: rgba(246,243,238,0.62); }
-        .defrag-kicker { font-size:12px; letter-spacing:0.18em; text-transform:uppercase; color: rgba(246,243,238,0.46); }
-        .defrag-card { border:1px solid rgba(255,255,255,0.08); background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015)); }
-        .defrag-button { background:#f6f3ee; color:#050505; border:none; padding:12px 16px; font-weight:600; cursor:pointer; }
-        .defrag-button.secondary { background:transparent; color:#f6f3ee; border:1px solid rgba(255,255,255,0.12); }
-        .defrag-textarea { width:100%; min-height:140px; resize:vertical; background:#0a0a0a; color:#f6f3ee; border:1px solid rgba(255,255,255,0.12); padding:14px; }
-        .field-node { position:absolute; width:128px; height:128px; border-radius:999px; border:1px solid rgba(255,255,255,0.16); display:flex; align-items:center; justify-content:center; flex-direction:column; backdrop-filter: blur(8px); background: radial-gradient(circle at 50% 50%, rgba(255,255,255,0.08), rgba(255,255,255,0.02)); box-shadow: 0 0 0 1px rgba(255,255,255,0.02), 0 0 40px rgba(255,255,255,0.04); }
-        .field-node::after { content:""; position:absolute; inset:-10px; border-radius:999px; border:1px solid rgba(214,195,161,0.16); opacity:0.55; }
-        .field-edge { position:absolute; left:50%; top:50%; width:240px; height:1px; background: linear-gradient(90deg, rgba(214,195,161,0.18), rgba(255,255,255,0.34), rgba(214,195,161,0.18)); transform: translate(-50%, -50%); }
-        .thread-bubble { padding:14px 16px; max-width:92%; border:1px solid rgba(255,255,255,0.08); }
-        .thread-bubble.user { background: rgba(255,255,255,0.03); margin-left:auto; }
-        .thread-bubble.assistant { background: rgba(214,195,161,0.08); }
-        @media (max-width: 1100px) {
-          .defrag-shell { grid-template-columns: 340px minmax(0,1fr); }
-          .defrag-branches { display:none; }
+        .ws-shell { display:grid; grid-template-columns: 380px minmax(0,1fr) 380px; min-height:100vh; }
+        .ws-col { border-right:1px solid rgba(255,255,255,0.08); }
+        .ws-col:last-child { border-right:none; }
+        .ws-left, .ws-center, .ws-right { display:grid; }
+        .ws-left { grid-template-rows:auto auto 1fr; }
+        .ws-center { grid-template-rows:auto 1fr auto; }
+        .ws-right { align-content:start; }
+        .ws-block { padding:22px; }
+        .ws-header { border-bottom:1px solid rgba(255,255,255,0.08); }
+        .ws-kicker { font-size:11px; letter-spacing:0.18em; text-transform:uppercase; color:rgba(246,243,238,0.46); }
+        .ws-muted { color: rgba(246,243,238,0.62); }
+        .ws-title { margin:0; font-size:34px; line-height:0.98; font-family: var(--font-display), serif; }
+        .ws-card { border:1px solid rgba(255,255,255,0.09); background: rgba(255,255,255,0.02); }
+        .ws-textarea { width:100%; min-height:140px; resize:vertical; background:#0a0a0a; color:#f6f3ee; border:1px solid rgba(255,255,255,0.12); padding:14px; line-height:1.65; }
+        .ws-btn { background:#f6f3ee; color:#050505; border:none; padding:12px 16px; font-weight:600; cursor:pointer; }
+        .ws-btn.secondary { background:transparent; color:#f6f3ee; border:1px solid rgba(255,255,255,0.12); }
+        .ws-thread { display:grid; gap:12px; padding:0 22px 22px; align-content:start; }
+        .ws-bubble { padding:14px 16px; border:1px solid rgba(255,255,255,0.08); line-height:1.7; }
+        .ws-bubble.user { background: rgba(255,255,255,0.03); margin-left:auto; max-width:94%; }
+        .ws-bubble.assistant { background: rgba(214,195,161,0.08); max-width:94%; }
+        .ws-canvas { position:relative; overflow:hidden; min-height:560px; }
+        .ws-canvas::before { content:""; position:absolute; inset:0; background:radial-gradient(circle at 50% 50%, rgba(214,195,161,0.06), transparent 40%); }
+        .ws-canvas::after { content:""; position:absolute; inset:0; background-image: linear-gradient(rgba(255,255,255,0.018) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.018) 1px, transparent 1px); background-size:32px 32px; opacity:0.12; }
+        .ws-node { position:absolute; width:136px; height:136px; border-radius:999px; border:1px solid rgba(255,255,255,0.16); display:flex; align-items:center; justify-content:center; flex-direction:column; backdrop-filter: blur(8px); background: rgba(255,255,255,0.02); z-index:2; }
+        .ws-edge { position:absolute; left:50%; top:50%; width:240px; height:1px; background: linear-gradient(90deg, rgba(255,255,255,0.1), rgba(255,255,255,0.3), rgba(255,255,255,0.1)); transform: translate(-50%, -50%); z-index:1; }
+        .ws-panel-list { display:grid; gap:12px; padding:22px; }
+        .ws-tag { font-size:10px; letter-spacing:0.14em; text-transform:uppercase; color:rgba(246,243,238,0.5); }
+        .ws-list { margin:0; padding-left:18px; display:grid; gap:8px; line-height:1.55; color:rgba(246,243,238,0.82); }
+        @media (max-width: 1180px) {
+          .ws-shell { grid-template-columns: 360px minmax(0,1fr); }
+          .ws-right { border-top:1px solid rgba(255,255,255,0.08); grid-column:1 / -1; }
+          .ws-panel-list { grid-template-columns: repeat(2, minmax(0,1fr)); display:grid; }
         }
-        @media (max-width: 820px) {
-          .defrag-shell { grid-template-columns: 1fr; }
-          .defrag-panel { border-right:none; border-bottom:1px solid rgba(255,255,255,0.08); }
-          .defrag-chat { order:1; }
-          .defrag-field { order:2; }
-          .defrag-branches { display:block; order:3; }
+        @media (max-width: 840px) {
+          .ws-shell { grid-template-columns: 1fr; }
+          .ws-col { border-right:none; border-bottom:1px solid rgba(255,255,255,0.08); }
+          .ws-panel-list { grid-template-columns: 1fr; }
+          .ws-canvas { min-height:420px; }
         }
       `}</style>
 
-      <div className="defrag-shell">
-        <section className="defrag-panel defrag-chat" style={{ padding: 24, display: "grid", gap: 20 }}>
-          <div style={{ display: "grid", gap: 10 }}>
-            <div className="defrag-kicker">Defrag workspace</div>
-            <h1 style={{ margin: 0, fontSize: 38, lineHeight: 1 }}>Relationship workspace</h1>
-            <p className="defrag-muted" style={{ margin: 0, lineHeight: 1.6 }}>
-              A calm space to understand what may be happening, what each person may be carrying, and what could help next.
+      <div className="ws-shell">
+        <section className="ws-col ws-left">
+          <div className="ws-block ws-header" style={{ display: "grid", gap: 10 }}>
+            <div className="ws-kicker">Defrag workspace</div>
+            <h1 className="ws-title">Relationship workspace</h1>
+            <p className="ws-muted" style={{ margin: 0, lineHeight: 1.65 }}>
+              Bring your baseline into this space to read one relationship moment clearly and choose a constructive next step.
             </p>
           </div>
 
-          <div className="defrag-card" style={{ padding: 16, display: "grid", gap: 12 }}>
-            <div className="defrag-kicker">Describe the situation</div>
-            <textarea className="defrag-textarea" value={message} onChange={(e) => setMessage(e.target.value)} />
+          <div className="ws-block" style={{ display: "grid", gap: 12 }}>
+            <div className="ws-kicker">Describe one moment</div>
+            <textarea className="ws-textarea" value={message} onChange={(e) => setMessage(e.target.value)} />
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-              <button className="defrag-button" onClick={interpret} disabled={loading}>
-                {loading ? "Reading the situation..." : "See what may be happening"}
+              <button className="ws-btn" onClick={interpret} disabled={loading}>
+                {loading ? "Reading the moment..." : "Analyze this moment"}
               </button>
-              <button className="defrag-button secondary" onClick={() => setMessage(INITIAL_MESSAGE)}>
+              <button className="ws-btn secondary" onClick={() => setMessage(INITIAL_MESSAGE)}>
                 Reset example
               </button>
             </div>
           </div>
 
           <div style={{ display: "grid", gap: 12 }}>
-            <div className="defrag-kicker">Thread</div>
-            {transcript.length === 0 ? (
-              <div className="defrag-card" style={{ padding: 16 }}>
-                <div className="defrag-muted">Run the workspace once to open the first conversation and field state.</div>
-              </div>
-            ) : (
-              transcript.map((entry, index) => (
-                <div key={`${entry.role}-${index}`} className={`thread-bubble ${entry.role}`}>
-                  <div className="defrag-kicker" style={{ marginBottom: 8 }}>
-                    {entry.role === "user" ? "You" : "Defrag"}
-                  </div>
-                  <div style={{ lineHeight: 1.7 }}>{entry.body}</div>
+            <div className="ws-block ws-header" style={{ paddingTop: 14, paddingBottom: 14 }}>
+              <div className="ws-kicker">Conversation thread</div>
+            </div>
+            <div className="ws-thread">
+              {transcript.length === 0 ? (
+                <div className="ws-card" style={{ padding: 16 }}>
+                  <div className="ws-muted">Run your first read to open the thread, then compare it with your baseline guidance.</div>
                 </div>
-              ))
-            )}
+              ) : (
+                transcript.map((entry, index) => (
+                  <div key={`${entry.role}-${index}`} className={`ws-bubble ${entry.role}`}>
+                    <div className="ws-kicker" style={{ marginBottom: 8 }}>
+                      {entry.role === "user" ? "You" : "Defrag"}
+                    </div>
+                    <div>{entry.body}</div>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
         </section>
 
-        <section className="defrag-panel defrag-field" style={{ padding: 24, display: "grid", gridTemplateRows: "auto 1fr auto", gap: 18 }}>
-          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "end" }}>
+        <section className="ws-col ws-center">
+          <div className="ws-block ws-header" style={{ display: "flex", justifyContent: "space-between", alignItems: "end", gap: 12 }}>
             <div style={{ display: "grid", gap: 8 }}>
-              <div className="defrag-kicker">Live field</div>
-              <h2 style={{ margin: 0, fontSize: 30 }}>What may be happening between people</h2>
+              <div className="ws-kicker">Live field</div>
+              <h2 style={{ margin: 0, fontSize: 30, lineHeight: 1.08 }}>Read the interaction clearly</h2>
             </div>
-            {result && (
-              <div className="defrag-card" style={{ padding: "10px 12px", minWidth: 220 }}>
-                <div className="defrag-kicker">Current pattern</div>
-                <div style={{ marginTop: 6 }}>{result.field_update.field_state.dominant_pattern}</div>
-              </div>
-            )}
+            <div className="ws-card" style={{ padding: "10px 12px", minWidth: 220 }}>
+              <div className="ws-kicker">Current pattern</div>
+              <div style={{ marginTop: 6 }}>{result?.field_update.field_state.dominant_pattern ?? "Waiting for first read"}</div>
+            </div>
           </div>
 
-          <div className="defrag-card" style={{ position: "relative", minHeight: 540, overflow: "hidden" }}>
-            <div style={{ position: "absolute", inset: 0, background: "radial-gradient(circle at 50% 50%, rgba(214,195,161,0.07), transparent 46%), radial-gradient(circle at 20% 20%, rgba(255,255,255,0.04), transparent 28%)" }} />
+          <div className="ws-canvas ws-card">
             {result ? (
               <>
-                <div className="field-edge" />
+                <div className="ws-edge" />
                 {result.field_update.visual_state.nodes.map((node) => (
                   <div
                     key={node.id}
-                    className="field-node"
+                    className="ws-node"
                     style={{
                       left: `${node.x * 100}%`,
                       top: `${node.y * 100}%`,
                       transform: `translate(-50%, -50%) scale(${node.size})`,
                     }}
                   >
-                    <div className="defrag-kicker" style={{ fontSize: 11 }}>{node.role ?? "person"}</div>
+                    <div className="ws-kicker" style={{ fontSize: 10 }}>{node.role ?? "person"}</div>
                     <div style={{ fontSize: 24, fontFamily: "var(--font-display), serif" }}>{node.label}</div>
-                    <div className="defrag-muted" style={{ fontSize: 13 }}>{node.state}</div>
+                    <div className="ws-muted" style={{ fontSize: 12 }}>{node.state}</div>
                   </div>
                 ))}
-                <div style={{ position: "absolute", left: 24, bottom: 24, width: "min(420px, calc(100% - 48px))" }} className="defrag-card">
-                  <div style={{ padding: 16, display: "grid", gap: 10 }}>
-                    <div className="defrag-kicker">Field reading</div>
-                    <div style={{ fontSize: 22, fontFamily: "var(--font-display), serif" }}>{result.assistant_message.title}</div>
-                    <div className="defrag-muted" style={{ lineHeight: 1.7 }}>{result.field_update.thread.summary}</div>
+                <div style={{ position: "absolute", left: 22, right: 22, bottom: 22, zIndex: 3 }} className="ws-card">
+                  <div style={{ padding: 14, display: "grid", gap: 8 }}>
+                    <div className="ws-kicker">Field reading</div>
+                    <div style={{ fontSize: 20, fontFamily: "var(--font-display), serif" }}>{result.assistant_message.title}</div>
+                    <div className="ws-muted" style={{ lineHeight: 1.65 }}>{result.field_update.thread.summary}</div>
                   </div>
                 </div>
               </>
             ) : (
               <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", padding: 32 }}>
-                <div style={{ maxWidth: 480, textAlign: "center", display: "grid", gap: 10 }}>
-                  <div className="defrag-kicker">Workspace preview</div>
-                  <div style={{ fontSize: 30, fontFamily: "var(--font-display), serif" }}>The visual field will appear here</div>
-                  <div className="defrag-muted" style={{ lineHeight: 1.7 }}>
-                    The center canvas will show the people involved, what may be happening between them, and where the situation may begin to open or close.
+                <div style={{ maxWidth: 520, textAlign: "center", display: "grid", gap: 10 }}>
+                  <div className="ws-kicker">Field preview</div>
+                  <div style={{ fontSize: 28, fontFamily: "var(--font-display), serif" }}>Your interaction map appears here</div>
+                  <div className="ws-muted" style={{ lineHeight: 1.7 }}>
+                    Run your first read to map people, pressure shifts, and where the conversation may open toward repair.
                   </div>
                 </div>
               </div>
             )}
           </div>
 
-          <div style={{ display: "grid", gap: 10 }}>
-            <div className="defrag-kicker">What could help next</div>
+          <div className="ws-block" style={{ display: "grid", gap: 10 }}>
+            <div className="ws-kicker">What could help next</div>
             <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
               {(result?.assistant_message.next_steps ?? [
                 "Start with what you want more of, not only what feels hard.",
-                "Keep the first step simple enough that it can be heard.",
-                "If the moment feels too heated, give it a little more room.",
+                "Keep the first step small enough that it can be heard.",
+                "If the moment is heated, create a little more room first.",
               ]).map((step) => (
-                <div key={step} className="defrag-card" style={{ padding: 14, lineHeight: 1.6 }}>
+                <div key={step} className="ws-card" style={{ padding: 14, lineHeight: 1.6 }}>
                   {step}
                 </div>
               ))}
@@ -252,28 +348,71 @@ export default function WorkspacePage() {
           </div>
         </section>
 
-        <aside className="defrag-panel defrag-branches" style={{ padding: 24, display: "grid", gap: 16, alignContent: "start" }}>
-          <div style={{ display: "grid", gap: 8 }}>
-            <div className="defrag-kicker">Branches</div>
-            <h2 style={{ margin: 0, fontSize: 28 }}>Open other views</h2>
-            <p className="defrag-muted" style={{ margin: 0, lineHeight: 1.6 }}>
-              These panels let the workspace open more depth without crowding the main thread.
-            </p>
+        <aside className="ws-col ws-right">
+          <div className="ws-block ws-header" style={{ display: "grid", gap: 8 }}>
+            <div className="ws-kicker">Story Canvas</div>
+            <h2 style={{ margin: 0, fontSize: 26 }}>{storyCanvas.scene.title}</h2>
+            <p className="ws-muted" style={{ margin: 0, lineHeight: 1.65 }}>{storyCanvas.scene.plainLanguageOverlay}</p>
+            <div className="ws-tag" style={{ marginTop: 2 }}>
+              Grammar: {storyCanvas.scene.grammarId}
+            </div>
           </div>
 
-          {(result?.field_update.branch_suggestions ?? [
-            { id: "other-side", label: "See from the other side", type: "perspective" },
-            { id: "calmer-way", label: "A calmer way to say it", type: "phrasing" },
-            { id: "family-view", label: "Family view", type: "family" },
-          ]).map((branch) => (
-            <div key={branch.id} className="defrag-card" style={{ padding: 16, display: "grid", gap: 10 }}>
-              <div className="defrag-kicker">{branch.type}</div>
-              <div style={{ fontSize: 20, fontFamily: "var(--font-display), serif" }}>{branch.label}</div>
-              <div className="defrag-muted" style={{ lineHeight: 1.6 }}>
-                This branch will open into its own thread so the user can follow one side of the situation without losing the main view.
-              </div>
-            </div>
-          ))}
+          <div className="ws-panel-list">
+            <section className="ws-card" style={{ padding: 14, display: "grid", gap: 10 }}>
+              <div className="ws-kicker">Story beats</div>
+              <ol className="ws-list">
+                {storyCanvas.scene.beats.map((beat) => (
+                  <li key={beat.id}>
+                    <div style={{ display: "grid", gap: 6 }}>
+                      <div>
+                        <strong>{beat.title}.</strong> {beat.selectedOverlay}
+                      </div>
+                      <div className="ws-tag">Focus: {beat.focus}</div>
+                      <div className="ws-muted">{beat.constructiveFrame}</div>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </section>
+
+            <section className="ws-card" style={{ padding: 14, display: "grid", gap: 10 }}>
+              <div className="ws-kicker">Annotations</div>
+              <ul className="ws-list" style={{ paddingLeft: 16 }}>
+                {storyCanvas.annotations.map((annotation) => (
+                  <li key={annotation.id}>
+                    <span className="ws-tag" style={{ marginRight: 8 }}>{annotation.category}</span>
+                    {annotation.message}
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            {storyCanvas.rewritePath ? (
+              <section className="ws-card" style={{ padding: 14, display: "grid", gap: 10 }}>
+                <div className="ws-kicker">Constructive rewrite</div>
+                <div style={{ fontWeight: 600 }}>{storyCanvas.rewritePath.title}</div>
+                <div className="ws-muted" style={{ lineHeight: 1.6 }}>
+                  <strong style={{ color: "#f6f3ee" }}>Before:</strong> {storyCanvas.rewritePath.before}
+                </div>
+                <div className="ws-muted" style={{ lineHeight: 1.6 }}>
+                  <strong style={{ color: "#f6f3ee" }}>After:</strong> {storyCanvas.rewritePath.after}
+                </div>
+                <div className="ws-tag">{storyCanvas.rewritePath.rationale}</div>
+              </section>
+            ) : null}
+
+            {placeholderPanels.map((panel) => (
+              <section key={panel.id} className="ws-card" style={{ padding: 14, display: "grid", gap: 8 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "center" }}>
+                  <div className="ws-kicker">{panel.subtitle}</div>
+                  <div className="ws-tag">{panel.state}</div>
+                </div>
+                <div style={{ fontSize: 20, fontFamily: "var(--font-display), serif" }}>{panel.title}</div>
+                <div className="ws-muted" style={{ lineHeight: 1.6 }}>{panel.body}</div>
+              </section>
+            ))}
+          </div>
         </aside>
       </div>
     </main>

--- a/packages/provider-router/__tests__/fallback.test.ts
+++ b/packages/provider-router/__tests__/fallback.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveFallback } from "../core/resolveFallback";
+import { routeTask } from "../core/router";
+
+describe("fallback routing", () => {
+  it("uses fallback provider when primary is unavailable", () => {
+    expect(routeTask({ type: "reasoning", input: "analyze" }, "openai")).toEqual({
+      status: "ok",
+      provider: "google",
+      reason: "fallback used",
+    });
+  });
+
+  it("is deterministic across repeated fallback calls", () => {
+    const task = { type: "reasoning", input: "repeatability" } as const;
+
+    const firstFallback = resolveFallback(task, "openai");
+    const secondFallback = resolveFallback(task, "openai");
+
+    expect(firstFallback?.id).toBe("google");
+    expect(secondFallback?.id).toBe("google");
+  });
+
+  it("returns no-route when fallback does not exist", () => {
+    expect(routeTask({ type: "image", prompt: "a tree" }, "openai")).toEqual({
+      status: "no-route",
+      reason: "no provider supports task",
+    });
+  });
+});

--- a/packages/provider-router/__tests__/router.test.ts
+++ b/packages/provider-router/__tests__/router.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { routeTask } from "../core/router";
+import type { Task } from "../types/tasks";
+
+describe("routeTask", () => {
+  it("routes reasoning tasks to openai", () => {
+    expect(routeTask({ type: "reasoning", input: "analyze" })).toEqual({
+      status: "ok",
+      provider: "openai",
+      reason: "matched capability",
+    });
+  });
+
+  it("routes image tasks to openai", () => {
+    expect(routeTask({ type: "image", prompt: "a mountain" })).toEqual({
+      status: "ok",
+      provider: "openai",
+      reason: "matched capability",
+    });
+  });
+
+  it("routes video tasks to google", () => {
+    expect(routeTask({ type: "video", prompt: "a tutorial" })).toEqual({
+      status: "ok",
+      provider: "google",
+      reason: "matched capability",
+    });
+  });
+
+  it("routes narration tasks to openai", () => {
+    expect(routeTask({ type: "narration", text: "read this" })).toEqual({
+      status: "ok",
+      provider: "openai",
+      reason: "matched capability",
+    });
+  });
+
+  it("returns no-route for unsupported task", () => {
+    const unsupportedTask = { type: "unsupported", input: "unknown" } as unknown as Task;
+
+    expect(routeTask(unsupportedTask)).toEqual({
+      status: "no-route",
+      reason: "no provider supports task",
+    });
+  });
+});

--- a/packages/provider-router/config/defaultRouting.ts
+++ b/packages/provider-router/config/defaultRouting.ts
@@ -1,0 +1,8 @@
+import type { Capability, ProviderId } from "../types/provider";
+
+export const DEFAULT_ROUTING: Record<Capability, ProviderId[]> = {
+  reasoning: ["openai", "google"],
+  image: ["openai"],
+  video: ["google"],
+  narration: ["openai"],
+};

--- a/packages/provider-router/core/resolveFallback.ts
+++ b/packages/provider-router/core/resolveFallback.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_ROUTING } from "../config/defaultRouting";
+import { googleProvider } from "../providers/google";
+import { openaiProvider } from "../providers/openai";
+import type { ProviderDefinition, ProviderId } from "../types/provider";
+import type { Task } from "../types/tasks";
+
+const PROVIDERS: Record<ProviderId, ProviderDefinition> = {
+  openai: openaiProvider,
+  google: googleProvider,
+};
+
+export function resolveFallback(task: Task, failedProviderId: ProviderId): ProviderDefinition | null {
+  const candidateProviderIds = DEFAULT_ROUTING[task.type as keyof typeof DEFAULT_ROUTING];
+
+  if (!candidateProviderIds) {
+    return null;
+  }
+
+  const failedIndex = candidateProviderIds.indexOf(failedProviderId);
+
+  if (failedIndex < 0) {
+    return null;
+  }
+
+  for (let index = failedIndex + 1; index < candidateProviderIds.length; index += 1) {
+    const providerId = candidateProviderIds[index];
+    const provider = PROVIDERS[providerId];
+    if (provider.capabilities.includes(task.type)) {
+      return provider;
+    }
+  }
+
+  return null;
+}

--- a/packages/provider-router/core/resolveProvider.ts
+++ b/packages/provider-router/core/resolveProvider.ts
@@ -1,0 +1,27 @@
+import { DEFAULT_ROUTING } from "../config/defaultRouting";
+import { googleProvider } from "../providers/google";
+import { openaiProvider } from "../providers/openai";
+import type { ProviderDefinition, ProviderId } from "../types/provider";
+import type { Task } from "../types/tasks";
+
+const PROVIDERS: Record<ProviderId, ProviderDefinition> = {
+  openai: openaiProvider,
+  google: googleProvider,
+};
+
+export function resolveProvider(task: Task): ProviderDefinition | null {
+  const candidateProviderIds = DEFAULT_ROUTING[task.type as keyof typeof DEFAULT_ROUTING];
+
+  if (!candidateProviderIds) {
+    return null;
+  }
+
+  for (const providerId of candidateProviderIds) {
+    const provider = PROVIDERS[providerId];
+    if (provider.capabilities.includes(task.type)) {
+      return provider;
+    }
+  }
+
+  return null;
+}

--- a/packages/provider-router/core/router.ts
+++ b/packages/provider-router/core/router.ts
@@ -1,0 +1,39 @@
+import { resolveFallback } from "./resolveFallback";
+import { resolveProvider } from "./resolveProvider";
+import type { ProviderId } from "../types/provider";
+import type { RouteResult } from "../types/routing";
+import type { Task } from "../types/tasks";
+
+export function routeTask(task: Task, unavailableProviderId?: ProviderId): RouteResult {
+  const primaryProvider = resolveProvider(task);
+
+  if (!primaryProvider) {
+    return {
+      status: "no-route",
+      reason: "no provider supports task",
+    };
+  }
+
+  if (!unavailableProviderId || primaryProvider.id !== unavailableProviderId) {
+    return {
+      status: "ok",
+      provider: primaryProvider.id,
+      reason: "matched capability",
+    };
+  }
+
+  const fallbackProvider = resolveFallback(task, unavailableProviderId);
+
+  if (!fallbackProvider) {
+    return {
+      status: "no-route",
+      reason: "no provider supports task",
+    };
+  }
+
+  return {
+    status: "ok",
+    provider: fallbackProvider.id,
+    reason: "fallback used",
+  };
+}

--- a/packages/provider-router/index.ts
+++ b/packages/provider-router/index.ts
@@ -1,0 +1,12 @@
+export { routeTask } from "./core/router";
+export { resolveProvider } from "./core/resolveProvider";
+export { resolveFallback } from "./core/resolveFallback";
+
+export { openaiProvider } from "./providers/openai";
+export { googleProvider } from "./providers/google";
+
+export { DEFAULT_ROUTING } from "./config/defaultRouting";
+
+export type { Task } from "./types/tasks";
+export type { Capability, ProviderDefinition, ProviderId } from "./types/provider";
+export type { RouteResult } from "./types/routing";

--- a/packages/provider-router/package.json
+++ b/packages/provider-router/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@defrag/provider-router",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts"
+  }
+}

--- a/packages/provider-router/providers/google.ts
+++ b/packages/provider-router/providers/google.ts
@@ -1,0 +1,7 @@
+import type { ProviderDefinition } from "../types/provider";
+
+export const googleProvider: ProviderDefinition = {
+  id: "google",
+  capabilities: ["reasoning", "video"],
+  priority: 50,
+};

--- a/packages/provider-router/providers/openai.ts
+++ b/packages/provider-router/providers/openai.ts
@@ -1,0 +1,7 @@
+import type { ProviderDefinition } from "../types/provider";
+
+export const openaiProvider: ProviderDefinition = {
+  id: "openai",
+  capabilities: ["reasoning", "image", "narration"],
+  priority: 100,
+};

--- a/packages/provider-router/types/provider.ts
+++ b/packages/provider-router/types/provider.ts
@@ -1,0 +1,9 @@
+export type ProviderId = "openai" | "google";
+
+export type Capability = "reasoning" | "image" | "video" | "narration";
+
+export type ProviderDefinition = {
+  id: ProviderId;
+  capabilities: Capability[];
+  priority: number;
+};

--- a/packages/provider-router/types/routing.ts
+++ b/packages/provider-router/types/routing.ts
@@ -1,0 +1,12 @@
+import type { ProviderId } from "./provider";
+
+export type RouteResult =
+  | {
+      status: "ok";
+      provider: ProviderId;
+      reason: string;
+    }
+  | {
+      status: "no-route";
+      reason: string;
+    };

--- a/packages/provider-router/types/tasks.ts
+++ b/packages/provider-router/types/tasks.ts
@@ -1,0 +1,5 @@
+export type Task =
+  | { type: "reasoning"; input: string }
+  | { type: "image"; prompt: string }
+  | { type: "video"; prompt: string }
+  | { type: "narration"; text: string };

--- a/packages/provider-router/vitest.config.ts
+++ b/packages/provider-router/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["__tests__/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/story-canvas/__tests__/grammars.test.ts
+++ b/packages/story-canvas/__tests__/grammars.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { storyCanvasGrammarRegistry } from "../index";
+
+const BANNED = [/villain/i, /humiliat/i, /manipulat/i, /diagnos/i];
+
+describe("story canvas grammar registry", () => {
+  it("includes all six required grammars", () => {
+    expect(Object.keys(storyCanvasGrammarRegistry).sort()).toEqual([
+      "cursedHouse",
+      "exileAndReturn",
+      "invisibleLabor",
+      "maskedProtector",
+      "repeatingTriangle",
+      "royalHierarchy",
+    ]);
+  });
+
+  it("keeps grammar copy policy-safe", () => {
+    for (const grammar of Object.values(storyCanvasGrammarRegistry)) {
+      for (const template of grammar.beatTemplates) {
+        const combined = `${grammar.intent} ${template.plainOverlayTemplate} ${template.cinematicOverlayTemplate}`;
+        for (const banned of BANNED) {
+          expect(combined).not.toMatch(banned);
+        }
+      }
+    }
+  });
+});

--- a/packages/story-canvas/__tests__/scene.test.ts
+++ b/packages/story-canvas/__tests__/scene.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildAnnotations } from "../core/buildAnnotations";
+import { buildRewrite } from "../core/buildRewrite";
+import { buildScene } from "../core/buildScene";
+import { sampleDynamic } from "../fixtures/sampleDynamic";
+import { royalHierarchyGrammar } from "../grammars/royalHierarchy";
+import { invisibleLaborGrammar } from "../grammars/invisibleLabor";
+
+describe("story canvas scene builders", () => {
+  it("buildScene is deterministic for the same input", () => {
+    const first = buildScene(sampleDynamic, royalHierarchyGrammar);
+    const second = buildScene(sampleDynamic, royalHierarchyGrammar);
+
+    expect(first).toEqual(second);
+  });
+
+  it("defaults to plain lens and supports plain + cinematic", () => {
+    const scene = buildScene(sampleDynamic, royalHierarchyGrammar);
+
+    expect(scene.lens).toBe("plain");
+    expect(scene.availableLenses).toEqual(["plain", "cinematic"]);
+    expect(scene.context.relationshipLabel).toBe(sampleDynamic.relationshipLabel);
+    expect(scene.plainLanguageOverlay).toContain(scene.context.sharedGoal);
+  });
+
+  it("annotation and rewrite outputs stay constructive and anti-stigma", () => {
+    const scene = buildScene(sampleDynamic, royalHierarchyGrammar, { lens: "cinematic" });
+    const annotations = buildAnnotations(scene);
+    const rewrites = buildRewrite(scene, annotations);
+
+    expect(annotations.length).toBeGreaterThan(0);
+    expect(rewrites.length).toBe(annotations.length);
+
+    const banned = [/villain/i, /humiliat/i, /manipulat/i, /diagnos/i];
+
+    for (const annotation of annotations) {
+      expect(annotation.constructive).toBe(true);
+      expect(annotation.message.toLowerCase()).toContain("dignity");
+      expect(annotation.message.toLowerCase()).toContain("concrete");
+      for (const rule of banned) {
+        expect(annotation.message).not.toMatch(rule);
+      }
+    }
+
+    for (const rewrite of rewrites) {
+      expect(rewrite.rationale.toLowerCase()).toContain("non-diagnostic");
+      expect(rewrite.after.toLowerCase()).toContain("i want us to move toward");
+      for (const rule of banned) {
+        expect(rewrite.after).not.toMatch(rule);
+      }
+    }
+  });
+
+  it("grammar-specific flavors stay differentiated for the same input", () => {
+    const royalScene = buildScene(sampleDynamic, royalHierarchyGrammar);
+    const laborScene = buildScene(sampleDynamic, invisibleLaborGrammar);
+
+    expect(royalScene.beats[0]?.selectedOverlay).not.toEqual(laborScene.beats[0]?.selectedOverlay);
+    expect(royalScene.beats[0]?.selectedOverlay.toLowerCase()).toContain("role pressure");
+    expect(laborScene.beats[0]?.selectedOverlay.toLowerCase()).toContain("unseen");
+  });
+});

--- a/packages/story-canvas/core/buildAnnotations.ts
+++ b/packages/story-canvas/core/buildAnnotations.ts
@@ -1,0 +1,54 @@
+import type { StoryCanvasScene } from "../types/scene";
+import type { Annotation } from "../types/annotations";
+
+const BANNED_PATTERNS = [/villain/i, /humiliat/i, /manipulat/i, /diagnos/i, /crazy/i, /broken/i];
+
+function enforcePolicyLanguage(message: string): string {
+  let normalized = message;
+  for (const pattern of BANNED_PATTERNS) {
+    normalized = normalized.replace(pattern, "harmful framing");
+  }
+
+  return normalized;
+}
+
+function categoryForFocus(focus: string): Annotation["category"] {
+  if (/loop|pressure|status|signal|clarity|thread|rule/i.test(focus)) {
+    return "clarity";
+  }
+  if (/repair|return|re-entry|bridge/i.test(focus)) {
+    return "repair";
+  }
+  if (/load|shared|distribution|agreement|coordination/i.test(focus)) {
+    return "coordination";
+  }
+  return "regulation";
+}
+
+export function buildAnnotations(scene: StoryCanvasScene): Annotation[] {
+  const relationship = scene.context.relationshipLabel;
+  const friction = scene.context.frictionPoint;
+
+  return scene.beats.map((beat, index) => {
+    const category = categoryForFocus(beat.focus);
+    const beatLead = index === 0 ? "First, orient the moment." : "Next, translate this into an action.";
+    const categoryGuide =
+      category === "clarity"
+        ? "Name what is happening without assigning character judgments."
+        : category === "repair"
+          ? "Keep the repair step voluntary, small, and specific."
+          : category === "coordination"
+            ? "Define who does what and when in concrete terms."
+            : "Keep pacing calm so both sides can stay present.";
+
+    return {
+      id: `annotation:${beat.id}`,
+      beatId: beat.id,
+      category,
+      message: enforcePolicyLanguage(
+        `${beatLead} In ${relationship}, ${beat.focus} is active around "${friction}". ${categoryGuide} Keep both people in dignity and choose language that stays concrete.`,
+      ),
+      constructive: true,
+    };
+  });
+}

--- a/packages/story-canvas/core/buildBeats.ts
+++ b/packages/story-canvas/core/buildBeats.ts
@@ -1,0 +1,147 @@
+import type { SampleDynamicInput } from "../fixtures/sampleDynamic";
+import type { NarrativeGrammar } from "../types/grammar";
+import type { LensMode } from "../types/lens";
+import type { StoryCanvasBeat } from "../types/beats";
+
+type GrammarFlavor = {
+  pressureFrames: string[];
+  actionFrames: string[];
+  cinematicFrames: string[];
+};
+
+const FLAVOR_BY_GRAMMAR: Record<string, GrammarFlavor> = {
+  royalHierarchy: {
+    pressureFrames: [
+      "Role pressure is shaping tone before intent is heard",
+      "Status cues are steering the exchange more than content",
+    ],
+    actionFrames: [
+      "Name the shared rule you both want to follow this week",
+      "Replace rank guessing with one explicit agreement",
+    ],
+    cinematicFrames: [
+      "Shift from throne-room tension to a shared table conversation",
+      "Move from protocol theater to a direct co-authored brief",
+    ],
+  },
+  cursedHouse: {
+    pressureFrames: [
+      "A familiar stress loop is replaying with small variations",
+      "The same hallway moment keeps returning under pressure",
+    ],
+    actionFrames: [
+      "Interrupt the loop with one low-stakes change in sequence",
+      "Choose a different first sentence to break the replay",
+    ],
+    cinematicFrames: [
+      "Open a window in the scene so pacing can reset",
+      "Change one camera angle to avoid repeating the same reaction shot",
+    ],
+  },
+  maskedProtector: {
+    pressureFrames: [
+      "Protection is present, but delivery may sound sharp",
+      "Care is active, yet armor is obscuring the signal",
+    ],
+    actionFrames: [
+      "Keep the boundary and soften the entry line",
+      "Name the care first, then state one clear limit",
+    ],
+    cinematicFrames: [
+      "Lower the shield enough for care to become audible",
+      "Let the mask tilt so intent can be seen without threat",
+    ],
+  },
+  exileAndReturn: {
+    pressureFrames: [
+      "Distance is carrying unmet needs from earlier moments",
+      "Separation has protected both sides but delayed repair",
+    ],
+    actionFrames: [
+      "Offer one consent-based re-entry step with clear timing",
+      "Create a return path that is small, specific, and voluntary",
+    ],
+    cinematicFrames: [
+      "Build a bridge scene with room for pauses and choice",
+      "Stage the return as a gentle crossing, not a forced reunion",
+    ],
+  },
+  repeatingTriangle: {
+    pressureFrames: [
+      "Indirect routes are increasing noise around the core issue",
+      "A third-point relay is carrying pressure meant for two voices",
+    ],
+    actionFrames: [
+      "Move one message back to direct dialogue between primary people",
+      "Remove one relay step and keep the exchange person-to-person",
+    ],
+    cinematicFrames: [
+      "Narrow the frame from three corners to one clear thread",
+      "Fade side channels so two direct voices can be heard",
+    ],
+  },
+  invisibleLabor: {
+    pressureFrames: [
+      "Hidden effort is shaping tension without being named",
+      "Unseen coordination load is distorting fairness signals",
+    ],
+    actionFrames: [
+      "List one invisible task and rebalance ownership concretely",
+      "Turn hidden maintenance into one shared weekly commitment",
+    ],
+    cinematicFrames: [
+      "Bring backstage work into the light with concrete credits",
+      "Re-block the scene so care work is visible and shareable",
+    ],
+  },
+};
+
+function compact(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function summarize(value: string, max = 96): string {
+  const normalized = compact(value);
+  if (normalized.length <= max) {
+    return normalized;
+  }
+  return `${normalized.slice(0, max - 1).trimEnd()}…`;
+}
+
+function deterministicIndex(seed: string, length: number): number {
+  let total = 0;
+  for (let index = 0; index < seed.length; index += 1) {
+    total = (total + seed.charCodeAt(index) * (index + 3)) % 2147483647;
+  }
+  return length === 0 ? 0 : total % length;
+}
+
+export function buildBeats(input: SampleDynamicInput, grammar: NarrativeGrammar, lens: LensMode): StoryCanvasBeat[] {
+  const flavor = FLAVOR_BY_GRAMMAR[grammar.id] ?? FLAVOR_BY_GRAMMAR.royalHierarchy;
+  const relationshipLabel = compact(input.relationshipLabel);
+  const friction = summarize(input.frictionPoint, 112);
+  const goal = summarize(input.sharedGoal, 92);
+  const weather = summarize(input.emotionalWeather, 96);
+
+  return grammar.beatTemplates.map((template, index) => {
+    const seed = `${grammar.id}:${template.key}:${relationshipLabel}:${friction}:${goal}:${weather}`;
+    const pressureFrame = flavor.pressureFrames[deterministicIndex(`${seed}:pressure`, flavor.pressureFrames.length)];
+    const actionFrame = flavor.actionFrames[deterministicIndex(`${seed}:action`, flavor.actionFrames.length)];
+    const cinematicFrame = flavor.cinematicFrames[deterministicIndex(`${seed}:cinematic`, flavor.cinematicFrames.length)];
+
+    const plainOverlay = `${template.plainOverlayTemplate} In ${relationshipLabel}, "${friction}" suggests ${pressureFrame.toLowerCase()}. Practical move: ${actionFrame}.`;
+    const cinematicOverlay = `${template.cinematicOverlayTemplate} Scene weather: ${weather}. ${cinematicFrame}. Keep the next move aligned with ${goal}.`;
+
+    return {
+      id: `${grammar.id}:${template.key}`,
+      order: index + 1,
+      title: template.title,
+      focus: template.focus,
+      plainOverlay,
+      cinematicOverlay,
+      selectedOverlay: lens === "cinematic" ? cinematicOverlay : plainOverlay,
+      lens,
+      constructiveFrame: `For ${relationshipLabel}, support ${goal} through one specific, respectful action that both sides can understand.`,
+    };
+  });
+}

--- a/packages/story-canvas/core/buildRewrite.ts
+++ b/packages/story-canvas/core/buildRewrite.ts
@@ -1,0 +1,29 @@
+import type { Annotation, RewritePath } from "../types/annotations";
+import type { StoryCanvasScene } from "../types/scene";
+
+export function buildRewrite(scene: StoryCanvasScene, annotations: Annotation[]): RewritePath[] {
+  const relationship = scene.context.relationshipLabel;
+  const friction = scene.context.frictionPoint;
+  const goal = scene.context.sharedGoal;
+
+  return scene.beats.map((beat, index) => {
+    const annotation = annotations[index];
+    const actionLine =
+      annotation?.category === "coordination"
+        ? "Can we choose one owner and one date for this step?"
+        : annotation?.category === "repair"
+          ? "Would you be open to one small reset conversation this week?"
+          : annotation?.category === "regulation"
+            ? "Could we pause for ten minutes and return when both of us are steadier?"
+            : "Can we restate the point in one sentence each before we respond?";
+
+    return {
+      id: `rewrite:${scene.id}:${index + 1}`,
+      title: `${beat.title}: clearer next wording`,
+      before: `When ${relationship} gets tense around "${friction}", we slip into ${beat.focus} and lose the thread.`,
+      after: `I want us to move toward ${goal}. I think ${beat.selectedOverlay.toLowerCase()} ${actionLine}`,
+      rationale:
+        "This rewrite keeps the language concrete, non-diagnostic, and collaborative while preserving clear boundaries.",
+    };
+  });
+}

--- a/packages/story-canvas/core/buildScene.ts
+++ b/packages/story-canvas/core/buildScene.ts
@@ -1,0 +1,38 @@
+import { buildBeats } from "./buildBeats";
+import { DEFAULT_LENS_MODE, SUPPORTED_LENS_MODES, type LensMode } from "../types/lens";
+import type { NarrativeGrammar } from "../types/grammar";
+import type { StoryCanvasScene } from "../types/scene";
+import type { SampleDynamicInput } from "../fixtures/sampleDynamic";
+
+export type BuildSceneOptions = {
+  lens?: LensMode;
+};
+
+function compact(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function buildScene(input: SampleDynamicInput, grammar: NarrativeGrammar, options: BuildSceneOptions = {}): StoryCanvasScene {
+  const lens = options.lens ?? DEFAULT_LENS_MODE;
+  const relationshipLabel = compact(input.relationshipLabel);
+  const sharedGoal = compact(input.sharedGoal);
+  const frictionPoint = compact(input.frictionPoint);
+  const emotionalWeather = compact(input.emotionalWeather);
+  const sceneId = `${grammar.id}:${relationshipLabel.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")}`;
+
+  return {
+    id: sceneId,
+    title: `${grammar.label} for ${relationshipLabel}`,
+    grammarId: grammar.id,
+    lens,
+    availableLenses: [...SUPPORTED_LENS_MODES],
+    plainLanguageOverlay: `${relationshipLabel}: keep the focus on ${sharedGoal} while addressing "${frictionPoint}" in a calm, specific way. Current weather: ${emotionalWeather}.`,
+    context: {
+      relationshipLabel,
+      frictionPoint,
+      sharedGoal,
+      emotionalWeather,
+    },
+    beats: buildBeats(input, grammar, lens),
+  };
+}

--- a/packages/story-canvas/fixtures/sampleDynamic.ts
+++ b/packages/story-canvas/fixtures/sampleDynamic.ts
@@ -1,0 +1,13 @@
+export type SampleDynamicInput = {
+  relationshipLabel: string;
+  frictionPoint: string;
+  sharedGoal: string;
+  emotionalWeather: string;
+};
+
+export const sampleDynamic: SampleDynamicInput = {
+  relationshipLabel: "co-parents",
+  frictionPoint: "household coordination feels uneven",
+  sharedGoal: "stabilize routines for the family",
+  emotionalWeather: "both feel stretched and protective",
+};

--- a/packages/story-canvas/grammars/cursedHouse.ts
+++ b/packages/story-canvas/grammars/cursedHouse.ts
@@ -1,0 +1,23 @@
+import type { NarrativeGrammar } from "../types/grammar";
+
+export const cursedHouseGrammar: NarrativeGrammar = {
+  id: "cursedHouse",
+  label: "Cursed House",
+  intent: "Surface repeating stress loops with care.",
+  beatTemplates: [
+    {
+      key: "echo",
+      title: "Echoed Hallway",
+      focus: "repeating loop",
+      plainOverlayTemplate: "Identify the repeating moment without labeling either person as the problem.",
+      cinematicOverlayTemplate: "Show the same hallway scene replaying until one gentle change is made.",
+    },
+    {
+      key: "light",
+      title: "Window Opened",
+      focus: "interrupt loop",
+      plainOverlayTemplate: "Choose one small interruption that lowers pressure.",
+      cinematicOverlayTemplate: "A window opens and fresh air changes the pacing of the scene.",
+    },
+  ],
+};

--- a/packages/story-canvas/grammars/exileAndReturn.ts
+++ b/packages/story-canvas/grammars/exileAndReturn.ts
@@ -1,0 +1,23 @@
+import type { NarrativeGrammar } from "../types/grammar";
+
+export const exileAndReturnGrammar: NarrativeGrammar = {
+  id: "exileAndReturn",
+  label: "Exile and Return",
+  intent: "Map distance and reconnection with grounded steps.",
+  beatTemplates: [
+    {
+      key: "distance",
+      title: "Distance Named",
+      focus: "separation",
+      plainOverlayTemplate: "Name the distance that formed and what each person needed.",
+      cinematicOverlayTemplate: "Track the journey apart with attention to unmet needs.",
+    },
+    {
+      key: "return",
+      title: "Bridge Back",
+      focus: "re-entry",
+      plainOverlayTemplate: "Offer one low-pressure step for return and repair.",
+      cinematicOverlayTemplate: "Build a bridge scene where return is steady and consent-based.",
+    },
+  ],
+};

--- a/packages/story-canvas/grammars/invisibleLabor.ts
+++ b/packages/story-canvas/grammars/invisibleLabor.ts
@@ -1,0 +1,23 @@
+import type { NarrativeGrammar } from "../types/grammar";
+
+export const invisibleLaborGrammar: NarrativeGrammar = {
+  id: "invisibleLabor",
+  label: "Invisible Labor",
+  intent: "Make hidden effort visible and shareable.",
+  beatTemplates: [
+    {
+      key: "inventory",
+      title: "Load Inventory",
+      focus: "hidden effort",
+      plainOverlayTemplate: "List unseen effort in specific and neutral language.",
+      cinematicOverlayTemplate: "Reveal backstage work that keeps the story moving.",
+    },
+    {
+      key: "redistribute",
+      title: "Fairer Distribution",
+      focus: "shared load",
+      plainOverlayTemplate: "Pick one concrete redistribution for this week.",
+      cinematicOverlayTemplate: "Re-block the scene so effort is visibly shared.",
+    },
+  ],
+};

--- a/packages/story-canvas/grammars/maskedProtector.ts
+++ b/packages/story-canvas/grammars/maskedProtector.ts
@@ -1,0 +1,23 @@
+import type { NarrativeGrammar } from "../types/grammar";
+
+export const maskedProtectorGrammar: NarrativeGrammar = {
+  id: "maskedProtector",
+  label: "Masked Protector",
+  intent: "Honor protective intent while improving delivery.",
+  beatTemplates: [
+    {
+      key: "shield",
+      title: "Shield Raised",
+      focus: "protective impulse",
+      plainOverlayTemplate: "Describe what is being protected in plain language.",
+      cinematicOverlayTemplate: "The mask drops just enough to reveal the care under the defense.",
+    },
+    {
+      key: "unmask",
+      title: "Signal Without Armor",
+      focus: "clean signal",
+      plainOverlayTemplate: "Rewrite the protective message so it lands without threat.",
+      cinematicOverlayTemplate: "Replace armor with a clear signal that keeps dignity intact.",
+    },
+  ],
+};

--- a/packages/story-canvas/grammars/repeatingTriangle.ts
+++ b/packages/story-canvas/grammars/repeatingTriangle.ts
@@ -1,0 +1,23 @@
+import type { NarrativeGrammar } from "../types/grammar";
+
+export const repeatingTriangleGrammar: NarrativeGrammar = {
+  id: "repeatingTriangle",
+  label: "Repeating Triangle",
+  intent: "Reduce third-point escalation and restore direct dialogue.",
+  beatTemplates: [
+    {
+      key: "triangle",
+      title: "Triangle Pattern",
+      focus: "indirect pressure",
+      plainOverlayTemplate: "Point out where a third point is carrying stress for the pair.",
+      cinematicOverlayTemplate: "Trace the triangle lines and then simplify the camera to two voices.",
+    },
+    {
+      key: "direct",
+      title: "Direct Thread",
+      focus: "two-person clarity",
+      plainOverlayTemplate: "Move the message back to direct, respectful dialogue.",
+      cinematicOverlayTemplate: "Cut away noise so two clear voices can connect.",
+    },
+  ],
+};

--- a/packages/story-canvas/grammars/royalHierarchy.ts
+++ b/packages/story-canvas/grammars/royalHierarchy.ts
@@ -1,0 +1,23 @@
+import type { NarrativeGrammar } from "../types/grammar";
+
+export const royalHierarchyGrammar: NarrativeGrammar = {
+  id: "royalHierarchy",
+  label: "Royal Hierarchy",
+  intent: "Clarify role pressure without blame.",
+  beatTemplates: [
+    {
+      key: "protocol",
+      title: "Protocol Pressure",
+      focus: "unspoken rules",
+      plainOverlayTemplate: "Name the rule both people are reacting to in simple terms.",
+      cinematicOverlayTemplate: "Frame the room as a court where status signals shape the next move.",
+    },
+    {
+      key: "alignment",
+      title: "Shared Charter",
+      focus: "aligned agreements",
+      plainOverlayTemplate: "Translate status conflict into one shared agreement.",
+      cinematicOverlayTemplate: "Shift from throne conflict to a signed charter for the next scene.",
+    },
+  ],
+};

--- a/packages/story-canvas/index.ts
+++ b/packages/story-canvas/index.ts
@@ -1,0 +1,36 @@
+export { buildScene } from "./core/buildScene";
+export { buildBeats } from "./core/buildBeats";
+export { buildAnnotations } from "./core/buildAnnotations";
+export { buildRewrite } from "./core/buildRewrite";
+
+export { sampleDynamic } from "./fixtures/sampleDynamic";
+
+export { royalHierarchyGrammar } from "./grammars/royalHierarchy";
+export { cursedHouseGrammar } from "./grammars/cursedHouse";
+export { maskedProtectorGrammar } from "./grammars/maskedProtector";
+export { exileAndReturnGrammar } from "./grammars/exileAndReturn";
+export { repeatingTriangleGrammar } from "./grammars/repeatingTriangle";
+export { invisibleLaborGrammar } from "./grammars/invisibleLabor";
+
+import { royalHierarchyGrammar } from "./grammars/royalHierarchy";
+import { cursedHouseGrammar } from "./grammars/cursedHouse";
+import { maskedProtectorGrammar } from "./grammars/maskedProtector";
+import { exileAndReturnGrammar } from "./grammars/exileAndReturn";
+import { repeatingTriangleGrammar } from "./grammars/repeatingTriangle";
+import { invisibleLaborGrammar } from "./grammars/invisibleLabor";
+
+export const storyCanvasGrammarRegistry = {
+  royalHierarchy: royalHierarchyGrammar,
+  cursedHouse: cursedHouseGrammar,
+  maskedProtector: maskedProtectorGrammar,
+  exileAndReturn: exileAndReturnGrammar,
+  repeatingTriangle: repeatingTriangleGrammar,
+  invisibleLabor: invisibleLaborGrammar,
+} as const;
+
+export type { StoryCanvasBeat } from "./types/beats";
+export type { StoryCanvasScene } from "./types/scene";
+export type { NarrativeGrammar, GrammarBeatTemplate } from "./types/grammar";
+export type { LensMode } from "./types/lens";
+export { DEFAULT_LENS_MODE, SUPPORTED_LENS_MODES } from "./types/lens";
+export type { Annotation, RewritePath, AnnotationCategory } from "./types/annotations";

--- a/packages/story-canvas/package.json
+++ b/packages/story-canvas/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@defrag/story-canvas",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts"
+  }
+}

--- a/packages/story-canvas/types/annotations.ts
+++ b/packages/story-canvas/types/annotations.ts
@@ -1,0 +1,17 @@
+export type AnnotationCategory = "clarity" | "regulation" | "repair" | "coordination";
+
+export type Annotation = {
+  id: string;
+  beatId: string;
+  category: AnnotationCategory;
+  message: string;
+  constructive: true;
+};
+
+export type RewritePath = {
+  id: string;
+  title: string;
+  before: string;
+  after: string;
+  rationale: string;
+};

--- a/packages/story-canvas/types/beats.ts
+++ b/packages/story-canvas/types/beats.ts
@@ -1,0 +1,13 @@
+import type { LensMode } from "./lens";
+
+export type StoryCanvasBeat = {
+  id: string;
+  order: number;
+  title: string;
+  focus: string;
+  plainOverlay: string;
+  cinematicOverlay: string;
+  selectedOverlay: string;
+  lens: LensMode;
+  constructiveFrame: string;
+};

--- a/packages/story-canvas/types/grammar.ts
+++ b/packages/story-canvas/types/grammar.ts
@@ -1,0 +1,14 @@
+export type GrammarBeatTemplate = {
+  key: string;
+  title: string;
+  focus: string;
+  plainOverlayTemplate: string;
+  cinematicOverlayTemplate: string;
+};
+
+export type NarrativeGrammar = {
+  id: string;
+  label: string;
+  intent: string;
+  beatTemplates: GrammarBeatTemplate[];
+};

--- a/packages/story-canvas/types/lens.ts
+++ b/packages/story-canvas/types/lens.ts
@@ -1,0 +1,4 @@
+export type LensMode = "plain" | "cinematic";
+
+export const SUPPORTED_LENS_MODES: readonly LensMode[] = ["plain", "cinematic"];
+export const DEFAULT_LENS_MODE: LensMode = "plain";

--- a/packages/story-canvas/types/scene.ts
+++ b/packages/story-canvas/types/scene.ts
@@ -1,0 +1,18 @@
+import type { StoryCanvasBeat } from "./beats";
+import type { LensMode } from "./lens";
+
+export type StoryCanvasScene = {
+  id: string;
+  title: string;
+  grammarId: string;
+  lens: LensMode;
+  availableLenses: LensMode[];
+  plainLanguageOverlay: string;
+  context: {
+    relationshipLabel: string;
+    frictionPoint: string;
+    sharedGoal: string;
+    emotionalWeather: string;
+  };
+  beats: StoryCanvasBeat[];
+};

--- a/packages/story-canvas/vitest.config.ts
+++ b/packages/story-canvas/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["__tests__/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
### Motivation
- Provide a local, deterministic Story Canvas foundation package (`packages/story-canvas`) for Defrag's visual narrative layer and integrate a lightweight provider routing helper (`packages/provider-router`) for capability-based task routing.
- Surface Story Canvas output inside the `/workspace` shell and harden web layout/fonts and environment guards to improve build reliability and preview experience.
- Improve product copy and phrasing across billing, landing, intake, auth, and onboarding pages to a clearer, non-stigmatizing tone.

### Description
- Added a new package `@defrag/story-canvas` with typed domain models, six narrative grammars, pure builders (`buildScene`, `buildBeats`, `buildAnnotations`, `buildRewrite`), a sample fixture, and a grammar registry exported from the package root under `packages/story-canvas/**`.
- Added a new package `@defrag/provider-router` implementing simple capability-based provider resolution and fallback (`resolveProvider`, `resolveFallback`, `routeTask`) plus provider definitions and routing config under `packages/provider-router/**`.
- Integrated Story Canvas into the web workspace at `apps/web/src/app/workspace/page.tsx` to derive `scene`, `annotations`, and a `rewritePath` from live workspace state and render a Story Canvas rail with beats, annotations, and rewrite suggestions; also added placeholder product-rail panels for future integration.
- Web hardening and copy polish: removed `next/font/google` usage and replaced with system-safe font stacks in `apps/web/src/app/layout.tsx`, added preview-env guards for Supabase in auth/onboarding pages, and updated phrasing and CTAs in multiple pages (`billing`, `intake`, `landing`, `login`, `signup`, `signin`, and studio variants).

### Testing
- Ran package-local unit tests for the new Story Canvas package with `pnpm --filter @defrag/story-canvas test`, which executed the Vitest suites (`scene.test.ts`, `grammars.test.ts`) and passed.
- Ran package-local unit tests for the provider router with `pnpm --filter @defrag/provider-router test`, which executed the Vitest suites (`router.test.ts`, `fallback.test.ts`) and passed.
- Ran a web typecheck with `pnpm --dir apps/web typecheck` after font and env-guard changes and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d2b029e84483328fa4ff98f7515b47)