### PR TITLE
Revamp UI layout, styles, and copy for intake, onboarding, auth, studio, and workspace

### DIFF
--- a/apps/web/src/app/intake/page.tsx
+++ b/apps/web/src/app/intake/page.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState } from "react";
 
 type BaselineApiResponse = {
   ok: boolean;
@@ -26,15 +26,15 @@ type BaselineApiResponse = {
 };
 
 const DEFAULT_CONTEXT =
-  'I want a clearer understanding of how I tend to react, what helps me feel steadier, and how that may affect my relationships.';
+  "I want a clearer understanding of how I tend to react, what helps me feel steadier, and how that may affect my relationships.";
 
 export default function IntakePage() {
   const [form, setForm] = useState({
-    name: '',
-    dob: '',
-    birth_time: '',
-    birth_place: '',
-    current_location: '',
+    name: "",
+    dob: "",
+    birth_time: "",
+    birth_place: "",
+    current_location: "",
     context: DEFAULT_CONTEXT,
   });
   const [result, setResult] = useState<BaselineApiResponse | null>(null);
@@ -45,9 +45,9 @@ export default function IntakePage() {
   async function generatePreview() {
     setLoading(true);
     try {
-      const res = await fetch('/api/test-baseline', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const res = await fetch("/api/test-baseline", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(form),
       });
       const data = (await res.json()) as BaselineApiResponse;
@@ -58,168 +58,177 @@ export default function IntakePage() {
   }
 
   return (
-    <main style={{ minHeight: '100vh', background: '#040404', color: '#f5f2ec' }}>
+    <main style={{ minHeight: "100vh", background: "#050505", color: "#f5f2ec" }}>
       <style>{`
-        .intake-shell { max-width: 1360px; margin: 0 auto; padding: 30px 22px 90px; display: grid; gap: 24px; }
-        .intake-topbar { display: flex; align-items: center; justify-content: space-between; gap: 14px; padding: 14px 16px; border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.02); backdrop-filter: blur(10px); }
-        .intake-brand { display: flex; align-items: center; gap: 12px; }
-        .intake-mark { width: 36px; height: 36px; border-radius: 999px; border: 1px solid rgba(214,195,161,0.24); display: grid; place-items: center; background: radial-gradient(circle at center, rgba(214,195,161,0.2), rgba(255,255,255,0.03)); box-shadow: 0 0 30px rgba(214,195,161,0.08); }
-        .intake-mark::after { content: ''; width: 16px; height: 16px; border-radius: 999px; background: rgba(245,242,236,0.82); box-shadow: 0 0 18px rgba(245,242,236,0.2); }
-        .intake-nav { display: flex; gap: 10px; flex-wrap: wrap; }
-        .intake-link { display: inline-flex; align-items: center; justify-content: center; text-decoration: none; padding: 9px 11px; border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.02); color: #f5f2ec; font-size: 12px; }
-        .intake-grid { display: grid; grid-template-columns: 1.02fr 0.98fr; gap: 22px; }
-        .intake-card { border: 1px solid rgba(255,255,255,0.08); background: linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.015)); box-shadow: 0 16px 40px rgba(0,0,0,0.18); }
-        .intake-copy { padding: 28px; display: grid; gap: 18px; align-content: start; }
-        .intake-phase { display: flex; gap: 8px; flex-wrap: wrap; }
-        .intake-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
-        .intake-muted { color: rgba(245,242,236,0.64); }
-        .intake-chip { display: inline-flex; align-items: center; gap: 6px; padding: 8px 10px; border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.02); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(245,242,236,0.62); }
-        .intake-title { margin: 0; font-size: 64px; line-height: 0.92; letter-spacing: -0.04em; font-family: var(--font-display), serif; }
-        .intake-stage { position: relative; overflow: hidden; min-height: 620px; }
-        .intake-stage::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 22% 18%, rgba(255,255,255,0.06), transparent 24%), radial-gradient(circle at 72% 22%, rgba(214,195,161,0.10), transparent 28%), radial-gradient(circle at 66% 76%, rgba(255,255,255,0.04), transparent 24%); }
-        .intake-stage::after { content: ''; position: absolute; inset: 0; background-image: linear-gradient(rgba(255,255,255,0.022) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.022) 1px, transparent 1px); background-size: 34px 34px; opacity: 0.12; }
-        .intake-stage > * { position: relative; z-index: 1; }
-        .intake-formgrid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 14px; }
-        .intake-field { display: grid; gap: 8px; }
-        .intake-input { width: 100%; border: 1px solid rgba(255,255,255,0.1); background: #0a0a0a; color: #f5f2ec; padding: 13px 14px; }
-        .intake-textarea { min-height: 140px; resize: vertical; }
-        .intake-btnrow { display: flex; gap: 10px; flex-wrap: wrap; }
-        .intake-btn { display: inline-flex; align-items: center; justify-content: center; text-decoration: none; border: none; background: #f5f2ec; color: #050505; padding: 13px 16px; font-weight: 600; }
-        .intake-btn.secondary { background: transparent; color: #f5f2ec; border: 1px solid rgba(255,255,255,0.1); }
-        .intake-stepgrid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 10px; }
-        .intake-step { padding: 14px 16px; border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.03); line-height: 1.66; }
-        .intake-preview { display: grid; gap: 16px; align-content: start; }
-        .intake-orb { position: absolute; border-radius: 999px; filter: blur(34px); opacity: 0.35; animation: intakeDrift 10s ease-in-out infinite; }
-        .intake-orb.a { width: 250px; height: 250px; left: -40px; top: 34px; background: rgba(214,195,161,0.16); }
-        .intake-orb.b { width: 180px; height: 180px; right: 30px; top: 120px; background: rgba(255,255,255,0.12); animation-delay: -4s; }
-        .intake-previewbox { padding: 24px; display: grid; gap: 14px; }
-        @keyframes intakeDrift { 0%, 100% { transform: translate3d(0,0,0); } 50% { transform: translate3d(16px,-12px,0); } }
+        .in-page { min-height: 100vh; background: radial-gradient(940px 620px at 82% 6%, rgba(214,195,161,0.13), transparent 68%), radial-gradient(780px 560px at 10% 24%, rgba(255,255,255,0.06), transparent 72%), linear-gradient(160deg, #090909, #050505 52%, #080808); }
+        .in-shell { width: min(1480px, 100%); margin: 0 auto; padding: clamp(24px, 3.2vw, 44px) clamp(18px, 3vw, 42px) 90px; display: grid; gap: clamp(26px, 4vw, 40px); }
+        .in-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
+        .in-muted { color: rgba(245,242,236,0.68); }
+
+        .in-top { display: flex; justify-content: space-between; gap: 14px; align-items: flex-start; }
+        .in-nav { display: flex; gap: 10px; flex-wrap: wrap; }
+        .in-link { text-decoration: none; color: #f5f2ec; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 10px 0; border-bottom: 1px solid rgba(245,242,236,0.22); opacity: 0.8; }
+
+        .in-grid { display: grid; grid-template-columns: minmax(0,1.02fr) minmax(0,0.98fr); gap: 22px; }
+        .in-panel { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.03); }
+
+        .in-left { padding: clamp(22px, 3.2vw, 40px); display: grid; gap: 16px; align-content: start; }
+        .in-title { margin: 0; font-family: var(--font-display), serif; font-size: clamp(2.35rem, 5.6vw, 5.3rem); line-height: 0.9; letter-spacing: -0.036em; max-width: 11ch; }
+        .in-stepbar { display: flex; gap: 8px; flex-wrap: wrap; }
+        .in-chip { padding: 8px 10px; border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.03); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(245,242,236,0.62); }
+
+        .in-formgrid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 12px; }
+        .in-field { display: grid; gap: 8px; }
+        .in-label { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(245,242,236,0.48); }
+        .in-input { width: 100%; border: 1px solid rgba(255,255,255,0.12); background: rgba(0,0,0,0.36); color: #f5f2ec; padding: 13px 14px; }
+        .in-input:focus { outline: 1px solid rgba(214,195,161,0.38); border-color: rgba(214,195,161,0.4); }
+        .in-textarea { min-height: 150px; resize: vertical; }
+
+        .in-cta { display: flex; gap: 10px; flex-wrap: wrap; }
+        .in-btn { border: 1px solid rgba(255,255,255,0.08); background: #f5f2ec; color: #050505; padding: 13px 16px; font-weight: 600; cursor: pointer; }
+        .in-btn:disabled { opacity: 0.65; cursor: default; }
+        .in-btn.secondary { background: rgba(255,255,255,0.03); color: #f5f2ec; border-color: rgba(255,255,255,0.12); text-decoration: none; display: inline-flex; align-items: center; }
+
+        .in-right { padding: clamp(22px, 3.2vw, 36px); display: grid; gap: 14px; align-content: start; position: relative; overflow: hidden; }
+        .in-right::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.08), transparent 30%), radial-gradient(circle at 72% 20%, rgba(214,195,161,0.14), transparent 36%), radial-gradient(circle at 72% 74%, rgba(255,255,255,0.06), transparent 30%); }
+        .in-right > * { position: relative; z-index: 1; }
+        .in-stepgrid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 10px; }
+        .in-card { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.035); padding: 14px; line-height: 1.66; }
+
         @media (max-width: 1120px) {
-          .intake-grid, .intake-stepgrid { grid-template-columns: 1fr; }
-          .intake-title { font-size: 48px; }
-          .intake-stage { min-height: auto; }
+          .in-grid, .in-stepgrid { grid-template-columns: 1fr; }
         }
         @media (max-width: 760px) {
-          .intake-formgrid { grid-template-columns: 1fr; }
-          .intake-title { font-size: 40px; }
-          .intake-topbar { align-items: flex-start; flex-direction: column; }
+          .in-top { flex-direction: column; }
+          .in-formgrid { grid-template-columns: 1fr; }
         }
       `}</style>
 
-      <div className='intake-shell'>
-        <header className='intake-topbar'>
-          <div className='intake-brand'>
-            <div className='intake-mark' />
-            <div style={{ display: 'grid', gap: 4 }}>
-              <div className='intake-kicker'>Defrag</div>
-              <div>Natal baseline walkthrough</div>
+      <div className="in-page">
+        <div className="in-shell">
+          <header className="in-top">
+            <div style={{ display: "grid", gap: 5 }}>
+              <div className="in-kicker">Defrag intake</div>
+              <div>Personal baseline setup</div>
             </div>
-          </div>
-          <nav className='intake-nav'>
-            <a className='intake-link' href='/studio'>Home</a>
-            <a className='intake-link' href='/workspace'>Workspace</a>
-            <a className='intake-link' href='/billing'>Billing</a>
-          </nav>
-        </header>
+            <nav className="in-nav">
+              <a className="in-link" href="/studio">
+                Studio
+              </a>
+              <a className="in-link" href="/workspace">
+                Workspace
+              </a>
+              <a className="in-link" href="/billing/studio">
+                Plans
+              </a>
+            </nav>
+          </header>
 
-        <section className='intake-grid'>
-          <section className='intake-card intake-copy'>
-            <div className='intake-kicker'>Guided intake</div>
-            <h1 className='intake-title'>Create your natal baseline in three short steps.</h1>
-            <div className='intake-phase'>
-              <span className='intake-chip'>Step 1 · Core birth details</span>
-              <span className='intake-chip'>Step 2 · Current context</span>
-              <span className='intake-chip'>Step 3 · Preview + workspace</span>
-            </div>
-            <div className='intake-muted' style={{ fontSize: 18, lineHeight: 1.78 }}>
-              Defrag uses these details to create a clear baseline you can carry into the workspace.
-            </div>
-            <div className='intake-muted' style={{ lineHeight: 1.78 }}>
-              You only need your date of birth to start. Add time, place, and context when available for a fuller baseline.
-            </div>
-
-            <div className='intake-formgrid'>
-              <label className='intake-field'>
-                <span className='intake-kicker'>Name</span>
-                <input className='intake-input' value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder='Optional' />
-              </label>
-              <label className='intake-field'>
-                <span className='intake-kicker'>Date of birth</span>
-                <input type='date' className='intake-input' value={form.dob} onChange={(e) => setForm({ ...form, dob: e.target.value })} />
-              </label>
-              <label className='intake-field'>
-                <span className='intake-kicker'>Birth time</span>
-                <input type='time' className='intake-input' value={form.birth_time} onChange={(e) => setForm({ ...form, birth_time: e.target.value })} />
-              </label>
-              <label className='intake-field'>
-                <span className='intake-kicker'>Birth place</span>
-                <input className='intake-input' value={form.birth_place} onChange={(e) => setForm({ ...form, birth_place: e.target.value })} placeholder='City, State, Country' />
-              </label>
-              <label className='intake-field'>
-                <span className='intake-kicker'>Current location</span>
-                <input className='intake-input' value={form.current_location} onChange={(e) => setForm({ ...form, current_location: e.target.value })} placeholder='Optional' />
-              </label>
-            </div>
-
-            <label className='intake-field'>
-              <span className='intake-kicker'>Relationship context</span>
-              <textarea className='intake-input intake-textarea' value={form.context} onChange={(e) => setForm({ ...form, context: e.target.value })} />
-            </label>
-            <div className='intake-muted' style={{ fontSize: 13, lineHeight: 1.68 }}>
-              This note helps Defrag frame your baseline around the moment you want to understand.
-            </div>
-
-            <div className='intake-btnrow'>
-              <button className='intake-btn' onClick={generatePreview} disabled={!ready || loading}>
-                {loading ? 'Creating preview...' : 'Create baseline preview'}
-              </button>
-              <a className='intake-btn secondary' href='/workspace'>Go to workspace</a>
-            </div>
-          </section>
-
-          <aside className='intake-card intake-stage'>
-            <div className='intake-orb a' />
-            <div className='intake-orb b' />
-            <div className='intake-previewbox'>
-              <div className='intake-kicker'>What you will get</div>
-              <div className='intake-stepgrid'>
-                <div className='intake-step'>A plain-language read of your core pattern.</div>
-                <div className='intake-step'>A short summary you can bring into workspace analysis.</div>
-                <div className='intake-step'>One grounded next step you can try right away.</div>
+          <section className="in-grid">
+            <section className="in-panel in-left">
+              <div className="in-kicker">Guided baseline sequence</div>
+              <h1 className="in-title">Create your baseline in one calm pass.</h1>
+              <div className="in-stepbar">
+                <span className="in-chip">Step 1 · core birth details</span>
+                <span className="in-chip">Step 2 · context note</span>
+                <span className="in-chip">Step 3 · preview + next step</span>
               </div>
-            </div>
+              <p className="in-muted" style={{ margin: 0, lineHeight: 1.8, maxWidth: 650 }}>
+                You only need your date of birth to begin. Add more details when available for a fuller baseline read.
+              </p>
 
-            <div className='intake-previewbox intake-preview'>
-              <div className='intake-kicker'>Preview</div>
+              <div className="in-formgrid">
+                <label className="in-field">
+                  <span className="in-label">Name</span>
+                  <input className="in-input" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="Optional" />
+                </label>
+                <label className="in-field">
+                  <span className="in-label">Date of birth</span>
+                  <input type="date" className="in-input" value={form.dob} onChange={(e) => setForm({ ...form, dob: e.target.value })} />
+                </label>
+                <label className="in-field">
+                  <span className="in-label">Birth time</span>
+                  <input type="time" className="in-input" value={form.birth_time} onChange={(e) => setForm({ ...form, birth_time: e.target.value })} />
+                </label>
+                <label className="in-field">
+                  <span className="in-label">Birth place</span>
+                  <input
+                    className="in-input"
+                    value={form.birth_place}
+                    onChange={(e) => setForm({ ...form, birth_place: e.target.value })}
+                    placeholder="City, State, Country"
+                  />
+                </label>
+                <label className="in-field" style={{ gridColumn: "1 / -1" }}>
+                  <span className="in-label">Current location</span>
+                  <input
+                    className="in-input"
+                    value={form.current_location}
+                    onChange={(e) => setForm({ ...form, current_location: e.target.value })}
+                    placeholder="Optional"
+                  />
+                </label>
+              </div>
+
+              <label className="in-field">
+                <span className="in-label">Relationship context</span>
+                <textarea className="in-input in-textarea" value={form.context} onChange={(e) => setForm({ ...form, context: e.target.value })} />
+              </label>
+
+              <div className="in-cta">
+                <button className="in-btn" onClick={generatePreview} disabled={!ready || loading}>
+                  {loading ? "Creating preview..." : "Create baseline preview"}
+                </button>
+                <a className="in-btn secondary" href="/workspace">
+                  Continue to workspace
+                </a>
+              </div>
+            </section>
+
+            <aside className="in-panel in-right">
+              <div className="in-kicker">What you receive</div>
+              <div className="in-stepgrid">
+                <div className="in-card">A plain-language read of your core pattern.</div>
+                <div className="in-card">A concise baseline summary for workspace use.</div>
+                <div className="in-card">One steady next step you can use quickly.</div>
+              </div>
+
+              <div className="in-kicker" style={{ marginTop: 4 }}>
+                Preview
+              </div>
               {result?.ok ? (
                 <>
-                  <div style={{ fontSize: 34, lineHeight: 1.04, fontFamily: 'var(--font-display), serif' }}>
-                    {result.baselineObject?.baseline?.core_design ?? 'Your baseline summary'}
+                  <div style={{ fontSize: 34, lineHeight: 1.02, fontFamily: "var(--font-display), serif" }}>
+                    {result.baselineObject?.baseline?.core_design ?? "Your baseline summary"}
                   </div>
-                  <div className='intake-muted' style={{ lineHeight: 1.74 }}>
-                    Confidence: {result.baselineObject?.meta?.confidence_level ?? 'medium'}
+                  <div className="in-muted" style={{ lineHeight: 1.72 }}>
+                    Confidence: {result.baselineObject?.meta?.confidence_level ?? "medium"}
                   </div>
-                  <div style={{ display: 'grid', gap: 10 }}>
+                  <div style={{ display: "grid", gap: 10 }}>
                     {(result.baselineObject?.baseline?.practical_guidance ?? []).map((item) => (
-                      <div key={item} className='intake-step'>{item}</div>
+                      <div key={item} className="in-card">
+                        {item}
+                      </div>
                     ))}
                   </div>
                   {result.baselineObject?.baseline?.one_clear_next_step ? (
-                    <div className='intake-step'>
-                      <div className='intake-kicker' style={{ marginBottom: 6 }}>One clear next step</div>
-                      <div>{result.baselineObject.baseline.one_clear_next_step}</div>
+                    <div className="in-card">
+                      <div className="in-kicker" style={{ marginBottom: 6 }}>
+                        One clear next step
+                      </div>
+                      {result.baselineObject.baseline.one_clear_next_step}
                     </div>
                   ) : null}
                 </>
               ) : (
-                <div className='intake-muted' style={{ lineHeight: 1.74 }}>
-                  Create a preview to see your natal baseline before you move into the workspace.
+                <div className="in-muted" style={{ lineHeight: 1.76 }}>
+                  Generate a preview to see your baseline before entering workspace interpretation.
                 </div>
               )}
-              {result?.warning ? <div className='intake-step'>{result.warning}</div> : null}
-            </div>
-          </aside>
-        </section>
+              {result?.warning ? <div className="in-card">{result.warning}</div> : null}
+            </aside>
+          </section>
+        </div>
       </div>
     </main>
   );

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -2,9 +2,7 @@
 
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AppShell } from "@/components/app-shell";
 import { createClient } from "@/utils/supabase/client";
-import { ArrowRight, User } from "lucide-react";
 
 const PREVIEW_ENV_ERROR =
   "Onboarding is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.";
@@ -21,123 +19,134 @@ function OnboardingContent() {
   const isInviteFlow = nextPath?.includes("/share/");
 
   const eyebrow = isInviteFlow ? "Almost there" : "Welcome";
-  const title = "Finish setting up your account.";
+  const title = isInviteFlow ? "Finish setup and open the shared summary." : "Finish setup and enter your workspace.";
   const description = isInviteFlow
-    ? "Before you open the shared summary, add your name so we can finish your setup."
-    : "Add your name to continue to your Defrag workspace.";
+    ? "Add your name so we can complete your account setup before opening the summary."
+    : "Add your name once so your workspace stays ready when you come back.";
 
   return (
-    <AppShell
-      eyebrow={eyebrow}
-      title={title}
-      description={description}
-      accent="#22d3ee"
-    >
-      <div style={{ maxWidth: 640, marginTop: 32 }}>
-        <div style={{ display: "grid", gap: 28 }}>
-          <div style={{ display: "grid", gap: 12 }}>
-            <label style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.18em", textTransform: "uppercase", color: "rgba(245, 245, 245, 0.4)" }}>
-              Your full name
-            </label>
-            <div style={{ display: "flex", alignItems: "center", gap: 14, borderRadius: 16, border: "1px solid rgba(255, 255, 255, 0.1)", background: "rgba(0,0,0,0.2)", padding: "16px 20px" }}>
-              <User style={{ width: 18, height: 18, color: "rgba(245, 245, 245, 0.4)" }} />
-              <input
-                value={displayName}
-                onChange={(event) => setDisplayName(event.target.value)}
-                placeholder="Jane Doe"
-                autoFocus
-                style={{
-                  width: "100%",
-                  border: "none",
-                  background: "transparent",
-                  color: "white",
-                  fontSize: 17,
-                  outline: "none",
-                  fontWeight: 400,
-                }}
-              />
-            </div>
-          </div>
+    <main style={{ minHeight: "100vh", background: "#050505", color: "#f5f2ec" }}>
+      <style>{`
+        .on-page { min-height: 100vh; background: radial-gradient(880px 620px at 80% 8%, rgba(214,195,161,0.12), transparent 70%), radial-gradient(760px 520px at 10% 20%, rgba(255,255,255,0.06), transparent 72%), linear-gradient(162deg, #090909, #050505 50%, #070707); }
+        .on-shell { width: min(1180px, 100%); margin: 0 auto; padding: clamp(24px, 3.5vw, 46px); display: grid; gap: 22px; }
+        .on-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
+        .on-muted { color: rgba(245,242,236,0.66); }
+        .on-grid { display: grid; grid-template-columns: minmax(0,1.02fr) minmax(0,0.98fr); gap: 22px; }
+        .on-panel { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.03); }
+        .on-left { padding: clamp(24px, 4vw, 44px); display: grid; gap: clamp(18px, 3vw, 30px); align-content: start; min-height: 640px; }
+        .on-title { margin: 0; font-family: var(--font-display), serif; font-size: clamp(2.35rem, 5.6vw, 4.6rem); line-height: 0.92; letter-spacing: -0.032em; max-width: 12ch; }
+        .on-stage { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.035); padding: 16px; line-height: 1.72; }
 
-          <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
-            <button
-              type="button"
-              onClick={async () => {
-                setBusy(true);
-                setError(null);
+        .on-right { padding: clamp(24px, 3.4vw, 40px); display: grid; gap: 14px; align-content: start; }
+        .on-label { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(245,242,236,0.48); }
+        .on-input { width: 100%; border: 1px solid rgba(255,255,255,0.12); background: rgba(0,0,0,0.36); color: #f5f2ec; padding: 14px 15px; }
+        .on-input:focus { outline: 1px solid rgba(214,195,161,0.38); border-color: rgba(214,195,161,0.4); }
+        .on-btn { width: fit-content; border: 1px solid rgba(255,255,255,0.08); background: #f5f2ec; color: #050505; padding: 14px 22px; font-weight: 600; cursor: pointer; }
+        .on-btn:disabled { opacity: 0.65; cursor: default; }
 
-                let supabase;
-                try {
-                  supabase = createClient();
-                } catch {
-                  setError(PREVIEW_ENV_ERROR);
-                  setBusy(false);
-                  return;
-                }
+        @media (max-width: 920px) {
+          .on-grid { grid-template-columns: 1fr; }
+          .on-left { min-height: auto; }
+        }
+      `}</style>
 
-                try {
-                  const {
-                    data: { user },
-                  } = await supabase.auth.getUser();
+      <div className="on-page">
+        <div className="on-shell">
+          <div className="on-kicker">{eyebrow}</div>
+          <section className="on-grid">
+            <article className="on-panel on-left">
+              <h1 className="on-title">{title}</h1>
+              <p className="on-muted" style={{ margin: 0, lineHeight: 1.82, maxWidth: 540 }}>
+                {description}
+              </p>
+              <div style={{ display: "grid", gap: 10 }}>
+                <div className="on-stage">This setup takes one step and keeps your account ready across baseline, workspace, and follow-up sessions.</div>
+                <div className="on-stage">Your name helps keep your workspace personal and easier to navigate when you return.</div>
+                <div className="on-stage">You stay in control of what you keep, share, and revisit later.</div>
+              </div>
+            </article>
 
-                  if (!user) {
-                    router.push("/login");
+            <section className="on-panel on-right">
+              <div style={{ display: "grid", gap: 8 }}>
+                <div className="on-kicker">Account setup</div>
+                <div style={{ fontFamily: "var(--font-display), serif", fontSize: 40, lineHeight: 0.94 }}>Add your name</div>
+              </div>
+
+              <label style={{ display: "grid", gap: 8 }}>
+                <span className="on-label">Your full name</span>
+                <input
+                  value={displayName}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  placeholder="Jane Doe"
+                  autoFocus
+                  className="on-input"
+                />
+              </label>
+
+              <button
+                type="button"
+                onClick={async () => {
+                  setBusy(true);
+                  setError(null);
+
+                  let supabase;
+                  try {
+                    supabase = createClient();
+                  } catch {
+                    setError(PREVIEW_ENV_ERROR);
+                    setBusy(false);
                     return;
                   }
 
-                  const metadata = {
-                    ...user.user_metadata,
-                    display_name: displayName.trim() || user.user_metadata?.display_name,
-                    onboarding_completed: true,
-                  };
+                  try {
+                    const {
+                      data: { user },
+                    } = await supabase.auth.getUser();
 
-                  const updateResult = await supabase.auth.updateUser({ data: metadata });
-                  if (updateResult.error) {
-                    throw updateResult.error;
+                    if (!user) {
+                      router.push("/login");
+                      return;
+                    }
+
+                    const metadata = {
+                      ...user.user_metadata,
+                      display_name: displayName.trim() || user.user_metadata?.display_name,
+                      onboarding_completed: true,
+                    };
+
+                    const updateResult = await supabase.auth.updateUser({ data: metadata });
+                    if (updateResult.error) {
+                      throw updateResult.error;
+                    }
+
+                    router.push(nextPath && nextPath.startsWith("/") ? nextPath : "/dynamics");
+                    router.refresh();
+                  } catch (err) {
+                    setError(err instanceof Error ? err.message : "Unable to complete setup");
+                  } finally {
+                    setBusy(false);
                   }
+                }}
+                disabled={busy || !displayName.trim()}
+                className="on-btn"
+              >
+                {busy ? "Saving..." : isInviteFlow ? "Open summary" : "Continue to workspace"}
+              </button>
 
-                  router.push(nextPath && nextPath.startsWith("/") ? nextPath : "/dynamics");
-                  router.refresh();
-                } catch (err) {
-                  setError(err instanceof Error ? err.message : "Unable to complete setup");
-                } finally {
-                  setBusy(false);
-                }
-              }}
-              disabled={busy || !displayName.trim()}
-              style={{
-                width: "fit-content",
-                padding: "16px 28px",
-                borderRadius: 14,
-                border: 0,
-                background: "white",
-                color: "#050505",
-                fontWeight: 600,
-                fontSize: 16,
-                cursor: busy || !displayName.trim() ? "default" : "pointer",
-                opacity: busy || !displayName.trim() ? 0.6 : 1,
-                display: "flex",
-                alignItems: "center",
-                gap: 10,
-              }}
-            >
-              {busy ? "Saving..." : isInviteFlow ? "Open summary" : "Continue to workspace"}
-              {!busy && <ArrowRight style={{ width: 18, height: 18 }} />}
-            </button>
+              <p className="on-muted" style={{ margin: 0, fontSize: 14, lineHeight: 1.72, maxWidth: 520 }}>
+                This keeps your workspace stable so you can return without repeating setup.
+              </p>
 
-            <p style={{ margin: 0, fontSize: 13, color: "rgba(245, 245, 245, 0.44)", lineHeight: 1.6, maxWidth: 440 }}>
-              Your account keeps your workspace ready when you come back. You stay in control of what you keep and share.
-            </p>
-          </div>
-
-          {error ? (
-            <div style={{ padding: 14, borderRadius: 14, background: "rgba(220, 38, 38, 0.1)", border: "1px solid rgba(220, 38, 38, 0.2)", color: "#fca5a5", fontSize: 13 }}>
-              {error}
-            </div>
-          ) : null}
+              {error ? (
+                <div style={{ padding: 12, border: "1px solid rgba(240,166,166,0.4)", background: "rgba(240,166,166,0.1)", color: "#f0a6a6", lineHeight: 1.6 }}>
+                  {error}
+                </div>
+              ) : null}
+            </section>
+          </section>
         </div>
       </div>
-    </AppShell>
+    </main>
   );
 }
 

--- a/apps/web/src/app/signin/studio/page.tsx
+++ b/apps/web/src/app/signin/studio/page.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { FormEvent, useState } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { createClient } from '@/utils/supabase/client';
+import { FormEvent, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
 
 const PREVIEW_ENV_ERROR =
-  'Sign in is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.';
+  "Sign in is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.";
 
 export default function StudioSignInPage() {
   const router = useRouter();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,67 +37,106 @@ export default function StudioSignInPage() {
       return;
     }
 
-    router.push('/app/studio');
+    router.push("/app/studio");
     router.refresh();
   }
 
   return (
-    <main style={{ minHeight: '100vh', background: '#040404', color: '#f5f2ec', display: 'grid', placeItems: 'center', padding: 22 }}>
+    <main style={{ minHeight: "100vh", background: "#050505", color: "#f5f2ec" }}>
       <style>{`
-        .signin-shell { width: min(1120px, 100%); display: grid; grid-template-columns: 1.02fr 0.98fr; gap: 22px; }
-        .signin-card { border: 1px solid rgba(255,255,255,0.08); background: linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.015)); box-shadow: 0 16px 40px rgba(0,0,0,0.18); }
-        .signin-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
-        .signin-muted { color: rgba(245,242,236,0.62); }
-        .signin-title { font-size: 64px; line-height: 0.92; letter-spacing: -0.03em; font-family: var(--font-display), serif; margin: 0; }
-        .signin-stage { position: relative; overflow: hidden; padding: 28px; display: grid; gap: 20px; }
-        .signin-stage::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.06), transparent 24%), radial-gradient(circle at 70% 20%, rgba(214,195,161,0.10), transparent 28%), radial-gradient(circle at 65% 72%, rgba(255,255,255,0.04), transparent 22%); }
-        .signin-stage > * { position: relative; z-index: 1; }
-        .signin-node { width: 164px; height: 164px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.14); background: radial-gradient(circle at center, rgba(255,255,255,0.09), rgba(255,255,255,0.015)); display: grid; place-items: center; text-align: center; box-shadow: 0 0 44px rgba(255,255,255,0.04); }
-        .signin-step { padding: 14px 16px; border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.03); line-height: 1.68; }
-        .signin-form { padding: 28px; display: grid; gap: 14px; }
-        .signin-input { padding: 14px 16px; background: #0a0a0a; color: #f5f2ec; border: 1px solid rgba(255,255,255,0.1); }
-        .signin-btn { border: 0; padding: 14px 18px; background: #f5f2ec; color: #050505; font-weight: 700; }
-        @media (max-width: 920px) { .signin-shell { grid-template-columns: 1fr; } .signin-title { font-size: 46px; } }
+        .si-page { min-height: 100vh; position: relative; overflow: hidden; background: radial-gradient(900px 620px at 80% 4%, rgba(214,195,161,0.12), transparent 70%), radial-gradient(800px 520px at 12% 18%, rgba(255,255,255,0.07), transparent 72%), linear-gradient(160deg, #090909, #050505 48%, #080808); }
+        .si-shell { width: min(1320px, 100%); margin: 0 auto; padding: clamp(22px, 3vw, 40px); display: grid; grid-template-columns: minmax(0,1.06fr) minmax(0,0.94fr); gap: clamp(20px, 3vw, 32px); }
+        .si-panel { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.03); }
+        .si-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
+        .si-muted { color: rgba(245,242,236,0.68); }
+
+        .si-left { padding: clamp(24px, 4vw, 44px); display: grid; gap: clamp(20px, 3vw, 34px); align-content: start; min-height: 760px; position: relative; overflow: hidden; }
+        .si-left::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 16% 18%, rgba(255,255,255,0.08), transparent 30%), radial-gradient(circle at 72% 22%, rgba(214,195,161,0.14), transparent 34%), radial-gradient(circle at 66% 74%, rgba(255,255,255,0.06), transparent 28%); opacity: 0.9; }
+        .si-left > * { position: relative; z-index: 1; }
+        .si-title { margin: 0; font-family: var(--font-display), serif; font-size: clamp(2.5rem, 6.4vw, 5.4rem); line-height: 0.9; letter-spacing: -0.036em; max-width: 11ch; }
+
+        .si-field { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.032); padding: 14px; line-height: 1.7; }
+        .si-nodewrap { display: flex; justify-content: center; padding-top: 8px; }
+        .si-node { width: 170px; height: 170px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.16); background: radial-gradient(circle at center, rgba(255,255,255,0.1), rgba(255,255,255,0.016)); display: grid; place-items: center; text-align: center; box-shadow: 0 0 54px rgba(214,195,161,0.1); }
+
+        .si-form { padding: clamp(24px, 3.4vw, 40px); display: grid; gap: 14px; align-content: start; }
+        .si-label { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(245,242,236,0.48); }
+        .si-input { width: 100%; border: 1px solid rgba(255,255,255,0.12); background: rgba(0,0,0,0.36); color: #f5f2ec; padding: 14px 15px; }
+        .si-input:focus { outline: 1px solid rgba(214,195,161,0.38); border-color: rgba(214,195,161,0.4); }
+        .si-btn { border: 1px solid rgba(255,255,255,0.08); background: #f5f2ec; color: #050505; padding: 14px 18px; font-weight: 600; cursor: pointer; }
+        .si-btn:disabled { opacity: 0.65; cursor: default; }
+        .si-legal { color: rgba(245,242,236,0.58); line-height: 1.7; font-size: 14px; }
+
+        @media (max-width: 980px) {
+          .si-shell { grid-template-columns: 1fr; }
+          .si-left { min-height: auto; }
+        }
       `}</style>
 
-      <section className='signin-shell'>
-        <div className='signin-card signin-stage'>
-          <div className='signin-kicker'>Premium access</div>
-          <h1 className='signin-title'>Return to your Defrag studio.</h1>
-          <div className='signin-muted' style={{ lineHeight: 1.76, maxWidth: 560 }}>
-            Sign in to continue your baseline, open workspace analysis, and manage billing in one place.
-          </div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0,1fr))', gap: 12 }}>
-            <div className='signin-step'>Baseline intake and profile</div>
-            <div className='signin-step'>Relationship workspace and mobile view</div>
-            <div className='signin-step'>Billing, plans, and account access</div>
-          </div>
-          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 12 }}>
-            <div className='signin-node'>
-              <div>
-                <div className='signin-kicker' style={{ fontSize: 10 }}>Defrag</div>
-                <div style={{ fontSize: 30, fontFamily: 'var(--font-display), serif' }}>Studio</div>
-                <div className='signin-muted' style={{ fontSize: 13 }}>premium workflow</div>
+      <div className="si-page">
+        <section className="si-shell">
+          <article className="si-panel si-left">
+            <div className="si-kicker">Premium access surface</div>
+            <h1 className="si-title">Return to your relationship studio.</h1>
+            <div className="si-muted" style={{ lineHeight: 1.8, maxWidth: 560 }}>
+              Sign in to continue your baseline, open the live field workspace, and keep your progress steady across devices.
+            </div>
+
+            <div style={{ display: "grid", gap: 10 }}>
+              <div className="si-field">Baseline and intake stay connected to your ongoing relationship work.</div>
+              <div className="si-field">Story Canvas and guided rewrites remain available in the same calm environment.</div>
+              <div className="si-field">Billing and account controls stay in one coherent premium flow.</div>
+            </div>
+
+            <div className="si-nodewrap">
+              <div className="si-node">
+                <div>
+                  <div className="si-kicker" style={{ fontSize: 10 }}>
+                    Defrag
+                  </div>
+                  <div style={{ fontFamily: "var(--font-display), serif", fontSize: 32 }}>Studio</div>
+                  <div className="si-muted" style={{ fontSize: 13 }}>
+                    calm clarity
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
+          </article>
 
-        <form onSubmit={handleSubmit} className='signin-card signin-form'>
-          <div style={{ display: 'grid', gap: 8 }}>
-            <div className='signin-kicker'>Access</div>
-            <div style={{ fontSize: 36, fontFamily: 'var(--font-display), serif' }}>Sign in</div>
-            <div className='signin-muted' style={{ lineHeight: 1.72 }}>Use your Defrag account to continue into your studio workspace and billing flow.</div>
-          </div>
-          <input className='signin-input' value={email} onChange={(e) => setEmail(e.target.value)} type='email' placeholder='Email' required />
-          <input className='signin-input' value={password} onChange={(e) => setPassword(e.target.value)} type='password' placeholder='Password' required />
-          {error ? <div style={{ color: '#fca5a5', lineHeight: 1.6 }}>{error}</div> : null}
-          <button type='submit' disabled={loading} className='signin-btn'>{loading ? 'Signing in...' : 'Continue to studio'}</button>
-          <div className='signin-muted' style={{ lineHeight: 1.7 }}>
-            Need an account? <Link href='/signup' style={{ color: '#f5f2ec' }}>Create one</Link>
-          </div>
-        </form>
-      </section>
+          <form onSubmit={handleSubmit} className="si-panel si-form">
+            <div style={{ display: "grid", gap: 8, marginBottom: 8 }}>
+              <div className="si-kicker">Sign in</div>
+              <div style={{ fontFamily: "var(--font-display), serif", fontSize: 42, lineHeight: 0.94 }}>Continue into your workspace</div>
+              <div className="si-muted" style={{ lineHeight: 1.75 }}>
+                Use your Defrag account to continue safely where you left off.
+              </div>
+            </div>
+
+            <label style={{ display: "grid", gap: 8 }}>
+              <span className="si-label">Email</span>
+              <input className="si-input" value={email} onChange={(e) => setEmail(e.target.value)} type="email" required />
+            </label>
+            <label style={{ display: "grid", gap: 8 }}>
+              <span className="si-label">Password</span>
+              <input className="si-input" value={password} onChange={(e) => setPassword(e.target.value)} type="password" required />
+            </label>
+
+            {error ? <div style={{ color: "#f0a6a6", lineHeight: 1.65 }}>{error}</div> : null}
+
+            <button type="submit" disabled={loading} className="si-btn">
+              {loading ? "Signing in..." : "Continue to studio"}
+            </button>
+
+            <div className="si-legal">
+              New here?{" "}
+              <Link href="/signup/studio" style={{ color: "#f5f2ec" }}>
+                Create your account
+              </Link>
+              .
+            </div>
+          </form>
+        </section>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/app/signup/studio/page.tsx
+++ b/apps/web/src/app/signup/studio/page.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import Link from 'next/link';
-import { FormEvent, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { createClient } from '@/utils/supabase/client';
+import Link from "next/link";
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
 
 const PREVIEW_ENV_ERROR =
-  'Account creation is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.';
+  "Account creation is unavailable in this preview environment. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to continue.";
 
 export default function StudioSignUpPage() {
   const router = useRouter();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -22,13 +22,13 @@ export default function StudioSignUpPage() {
     setError(null);
 
     if (password.length < 8) {
-      setError('Password must be at least 8 characters.');
+      setError("Password must be at least 8 characters.");
       setLoading(false);
       return;
     }
 
     if (password !== confirmPassword) {
-      setError('Passwords do not match.');
+      setError("Passwords do not match.");
       setLoading(false);
       return;
     }
@@ -56,57 +56,91 @@ export default function StudioSignUpPage() {
       return;
     }
 
-    router.push('/app/studio');
+    router.push("/app/studio");
     router.refresh();
   }
 
   return (
-    <main style={{ minHeight: '100vh', background: '#040404', color: '#f5f2ec', display: 'grid', placeItems: 'center', padding: 22 }}>
+    <main style={{ minHeight: "100vh", background: "#050505", color: "#f5f2ec" }}>
       <style>{`
-        .signup-shell { width: min(1120px, 100%); display: grid; grid-template-columns: 1.02fr 0.98fr; gap: 22px; }
-        .signup-card { border: 1px solid rgba(255,255,255,0.08); background: linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.015)); box-shadow: 0 16px 40px rgba(0,0,0,0.18); }
-        .signup-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
-        .signup-muted { color: rgba(245,242,236,0.62); }
-        .signup-title { font-size: 60px; line-height: 0.92; letter-spacing: -0.03em; font-family: var(--font-display), serif; margin: 0; }
-        .signup-stage { position: relative; overflow: hidden; padding: 28px; display: grid; gap: 18px; }
-        .signup-stage::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 18% 18%, rgba(255,255,255,0.06), transparent 24%), radial-gradient(circle at 72% 22%, rgba(214,195,161,0.10), transparent 28%), radial-gradient(circle at 66% 76%, rgba(255,255,255,0.04), transparent 24%); }
-        .signup-stage > * { position: relative; z-index: 1; }
-        .signup-step { padding: 14px 16px; border: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.03); line-height: 1.68; }
-        .signup-form { padding: 28px; display: grid; gap: 14px; }
-        .signup-input { padding: 14px 16px; background: #0a0a0a; color: #f5f2ec; border: 1px solid rgba(255,255,255,0.1); }
-        .signup-btn { border: 0; padding: 14px 18px; background: #f5f2ec; color: #050505; font-weight: 700; }
-        @media (max-width: 920px) { .signup-shell { grid-template-columns: 1fr; } .signup-title { font-size: 44px; } }
+        .su-page { min-height: 100vh; position: relative; overflow: hidden; background: radial-gradient(920px 620px at 82% 6%, rgba(214,195,161,0.14), transparent 68%), radial-gradient(720px 560px at 14% 22%, rgba(255,255,255,0.06), transparent 70%), linear-gradient(160deg, #090909, #050505 52%, #070707); }
+        .su-shell { width: min(1320px, 100%); margin: 0 auto; padding: clamp(22px, 3vw, 40px); display: grid; grid-template-columns: minmax(0,1.05fr) minmax(0,0.95fr); gap: clamp(20px, 3vw, 32px); }
+        .su-panel { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.03); }
+        .su-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
+        .su-muted { color: rgba(245,242,236,0.66); }
+
+        .su-left { padding: clamp(24px, 4vw, 44px); display: grid; gap: clamp(20px, 3vw, 34px); align-content: start; min-height: 760px; position: relative; overflow: hidden; }
+        .su-left::before { content: ''; position: absolute; inset: 0; background: radial-gradient(circle at 22% 16%, rgba(255,255,255,0.08), transparent 28%), radial-gradient(circle at 72% 28%, rgba(214,195,161,0.16), transparent 34%), radial-gradient(circle at 66% 74%, rgba(255,255,255,0.06), transparent 30%); opacity: 0.94; }
+        .su-left > * { position: relative; z-index: 1; }
+        .su-title { margin: 0; font-family: var(--font-display), serif; font-size: clamp(2.45rem, 6.2vw, 5.2rem); line-height: 0.9; letter-spacing: -0.035em; max-width: 11ch; }
+        .su-step { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.035); padding: 14px; line-height: 1.7; }
+
+        .su-form { padding: clamp(24px, 3.4vw, 40px); display: grid; gap: 14px; align-content: start; }
+        .su-label { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(245,242,236,0.48); }
+        .su-input { width: 100%; border: 1px solid rgba(255,255,255,0.12); background: rgba(0,0,0,0.36); color: #f5f2ec; padding: 14px 15px; }
+        .su-input:focus { outline: 1px solid rgba(214,195,161,0.38); border-color: rgba(214,195,161,0.4); }
+        .su-btn { border: 1px solid rgba(255,255,255,0.08); background: #f5f2ec; color: #050505; padding: 14px 18px; font-weight: 600; cursor: pointer; }
+        .su-btn:disabled { opacity: 0.65; cursor: default; }
+
+        @media (max-width: 980px) {
+          .su-shell { grid-template-columns: 1fr; }
+          .su-left { min-height: auto; }
+        }
       `}</style>
 
-      <section className='signup-shell'>
-        <div className='signup-card signup-stage'>
-          <div className='signup-kicker'>Create account</div>
-          <h1 className='signup-title'>Create your Defrag studio account.</h1>
-          <div className='signup-muted' style={{ lineHeight: 1.78 }}>
-            Create one account so baseline, workspace access, and billing stay connected in one premium flow.
-          </div>
-          <div style={{ display: 'grid', gap: 10 }}>
-            <div className='signup-step'>One account for baseline, workspace, and billing</div>
-            <div className='signup-step'>Premium studio surfaces across public and signed-in pages</div>
-            <div className='signup-step'>Built for ongoing use across intake, workspace, and account tools</div>
-          </div>
-        </div>
+      <div className="su-page">
+        <section className="su-shell">
+          <article className="su-panel su-left">
+            <div className="su-kicker">Premium onboarding access</div>
+            <h1 className="su-title">Create your Defrag studio account.</h1>
+            <div className="su-muted" style={{ lineHeight: 1.8, maxWidth: 560 }}>
+              One account keeps your baseline, workspace reads, and billing controls connected in one calm relationship-intelligence environment.
+            </div>
+            <div style={{ display: "grid", gap: 10 }}>
+              <div className="su-step">Use the same account across intake, workspace, and Story Canvas guidance.</div>
+              <div className="su-step">Keep your sessions and interpretation history in one steady flow.</div>
+              <div className="su-step">Continue safely later on desktop or mobile without re-framing everything again.</div>
+            </div>
+          </article>
 
-        <form onSubmit={handleSubmit} className='signup-card signup-form'>
-          <div style={{ display: 'grid', gap: 8 }}>
-            <div className='signup-kicker'>Access</div>
-            <div style={{ fontSize: 36, fontFamily: 'var(--font-display), serif' }}>Create account</div>
-          </div>
-          <input className='signup-input' value={email} onChange={(e) => setEmail(e.target.value)} type='email' placeholder='Email' required />
-          <input className='signup-input' value={password} onChange={(e) => setPassword(e.target.value)} type='password' placeholder='Password' required />
-          <input className='signup-input' value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} type='password' placeholder='Confirm password' required />
-          {error ? <div style={{ color: '#fca5a5', lineHeight: 1.6 }}>{error}</div> : null}
-          <button type='submit' disabled={loading} className='signup-btn'>{loading ? 'Creating account...' : 'Create account'}</button>
-          <div className='signup-muted' style={{ lineHeight: 1.7 }}>
-            Already have an account? <Link href='/signin/studio' style={{ color: '#f5f2ec' }}>Sign in</Link>
-          </div>
-        </form>
-      </section>
+          <form onSubmit={handleSubmit} className="su-panel su-form">
+            <div style={{ display: "grid", gap: 8, marginBottom: 8 }}>
+              <div className="su-kicker">Create account</div>
+              <div style={{ fontFamily: "var(--font-display), serif", fontSize: 42, lineHeight: 0.94 }}>Start your studio access</div>
+              <div className="su-muted" style={{ lineHeight: 1.75 }}>
+                Create your credentials once, then continue into your workspace.
+              </div>
+            </div>
+
+            <label style={{ display: "grid", gap: 8 }}>
+              <span className="su-label">Email</span>
+              <input className="su-input" value={email} onChange={(e) => setEmail(e.target.value)} type="email" required />
+            </label>
+            <label style={{ display: "grid", gap: 8 }}>
+              <span className="su-label">Password</span>
+              <input className="su-input" value={password} onChange={(e) => setPassword(e.target.value)} type="password" required />
+            </label>
+            <label style={{ display: "grid", gap: 8 }}>
+              <span className="su-label">Confirm password</span>
+              <input className="su-input" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} type="password" required />
+            </label>
+
+            {error ? <div style={{ color: "#f0a6a6", lineHeight: 1.65 }}>{error}</div> : null}
+
+            <button type="submit" disabled={loading} className="su-btn">
+              {loading ? "Creating account..." : "Create account"}
+            </button>
+
+            <div className="su-muted" style={{ lineHeight: 1.75 }}>
+              Already have an account?{" "}
+              <Link href="/signin/studio" style={{ color: "#f5f2ec" }}>
+                Sign in
+              </Link>
+              .
+            </div>
+          </form>
+        </section>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/app/studio/page.tsx
+++ b/apps/web/src/app/studio/page.tsx
@@ -1,17 +1,17 @@
 import Link from "next/link";
 
-const FLOW = [
+const FLOW_STEPS = [
   {
-    label: "Baseline",
-    body: "Start with a short natal baseline so Defrag understands how pressure may land for you.",
+    title: "Start with your baseline",
+    body: "Enter core birth details in simple language so Defrag can map how pressure may land for you.",
   },
   {
-    label: "Field read",
-    body: "Open one live relationship moment and map what may be happening between people.",
+    title: "Read one relationship moment",
+    body: "Open the live field to see where people may be missing each other and what each side may be carrying.",
   },
   {
-    label: "Next move",
-    body: "Leave with one clear step that protects dignity and lowers distortion.",
+    title: "Choose one healthier next step",
+    body: "Leave with a grounded move you can actually use in the next conversation.",
   },
 ];
 
@@ -19,469 +19,212 @@ export default function StudioHomePage() {
   return (
     <main style={{ minHeight: "100vh", background: "#050505", color: "#f5f2ec" }}>
       <style>{`
-        .st-page {
-          position: relative;
-          isolation: isolate;
-          overflow: hidden;
-          min-height: 100vh;
-          background:
-            radial-gradient(1200px 680px at 78% -8%, rgba(235, 219, 190, 0.12), transparent 64%),
-            radial-gradient(920px 620px at 18% 20%, rgba(255, 255, 255, 0.05), transparent 68%),
-            linear-gradient(160deg, #080808 0%, #050505 42%, #090909 100%);
+        .studio-page { position: relative; overflow: hidden; isolation: isolate; background: radial-gradient(980px 620px at 78% 8%, rgba(214,195,161,0.12), transparent 68%), radial-gradient(760px 540px at 12% 26%, rgba(255,255,255,0.06), transparent 72%), linear-gradient(164deg, #090909 0%, #050505 46%, #080808 100%); }
+        .studio-page::before { content: ''; position: absolute; inset: 0; opacity: 0.22; background-image: linear-gradient(rgba(255,255,255,0.018) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.018) 1px, transparent 1px); background-size: 40px 40px; pointer-events: none; }
+        .studio-shell { position: relative; z-index: 1; width: min(1520px, 100%); margin: 0 auto; padding: 34px clamp(18px, 3.2vw, 48px) 120px; display: grid; gap: clamp(56px, 10vw, 124px); }
+        .studio-topbar { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
+        .studio-brand { display: grid; gap: 6px; }
+        .studio-kicker { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(245,242,236,0.42); }
+        .studio-muted { color: rgba(245,242,236,0.68); }
+        .studio-nav { display: flex; gap: 10px; flex-wrap: wrap; }
+        .studio-navlink { text-decoration: none; color: #f5f2ec; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 10px 0; border-bottom: 1px solid rgba(245,242,236,0.24); opacity: 0.78; }
+        .studio-navlink:hover { opacity: 1; border-color: rgba(245,242,236,0.58); }
+
+        .studio-hero { display: grid; grid-template-columns: minmax(0,1.04fr) minmax(0,0.96fr); gap: clamp(28px, 5vw, 80px); align-items: start; }
+        .studio-left { display: grid; gap: clamp(30px, 4.4vw, 52px); align-content: start; padding-top: clamp(14px, 5vw, 96px); }
+        .studio-title { margin: 0; font-family: var(--font-display), serif; font-size: clamp(3rem, 8.2vw, 7.2rem); line-height: 0.88; letter-spacing: -0.044em; max-width: 13ch; text-wrap: balance; }
+        .studio-copy { margin: 0; line-height: 1.84; font-size: clamp(1rem, 1.42vw, 1.15rem); max-width: 54ch; }
+        .studio-cta { display: flex; gap: 12px; flex-wrap: wrap; }
+        .studio-btn { display: inline-flex; align-items: center; justify-content: center; border-radius: 999px; text-decoration: none; padding: 14px 22px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 12px; transition: transform 160ms ease, opacity 160ms ease; }
+        .studio-btn:hover { transform: translateY(-1px); }
+        .studio-btn.primary { background: #f5f2ec; color: #050505; font-weight: 600; }
+        .studio-btn.secondary { border: 1px solid rgba(255,255,255,0.18); color: #f5f2ec; background: rgba(255,255,255,0.03); }
+        .studio-btn.tertiary { padding-inline: 10px; color: rgba(245,242,236,0.72); border-bottom: 1px solid rgba(245,242,236,0.34); border-radius: 0; }
+
+        .studio-field { position: relative; min-height: 780px; border-radius: 30px; border: 1px solid rgba(255,255,255,0.12); overflow: hidden; background: radial-gradient(circle at 18% 24%, rgba(255,255,255,0.09), transparent 36%), radial-gradient(circle at 76% 70%, rgba(214,195,161,0.16), transparent 42%), linear-gradient(168deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015)); box-shadow: 0 24px 60px rgba(0,0,0,0.34), 0 0 90px rgba(214,195,161,0.08); }
+        .studio-field::after { content: ''; position: absolute; inset: 0; background-image: linear-gradient(rgba(255,255,255,0.024) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.024) 1px, transparent 1px); background-size: 34px 34px; opacity: 0.12; }
+        .studio-thread { position: absolute; left: 24px; top: 24px; width: min(420px, calc(100% - 48px)); display: grid; gap: 12px; z-index: 3; }
+        .studio-bubble { padding: 15px 16px; border: 1px solid rgba(255,255,255,0.1); backdrop-filter: blur(10px); line-height: 1.72; background: rgba(255,255,255,0.038); }
+        .studio-bubble.assistant { margin-left: 28px; background: linear-gradient(140deg, rgba(214,195,161,0.2), rgba(255,255,255,0.04)); }
+        .studio-linkline { position: absolute; left: 56%; top: 46%; width: 340px; height: 2px; transform: translate(-50%, -50%); background: linear-gradient(90deg, rgba(214,195,161,0), rgba(214,195,161,0.34), rgba(255,255,255,0.68), rgba(214,195,161,0.34), rgba(214,195,161,0)); z-index: 2; overflow: hidden; }
+        .studio-linkline::after { content: ''; position: absolute; top: 0; left: -28%; width: 28%; height: 100%; background: linear-gradient(90deg, transparent, rgba(255,255,255,0.72), transparent); animation: studioSweep 3.6s linear infinite; }
+        .studio-node { position: absolute; width: 170px; height: 170px; border-radius: 999px; display: grid; place-items: center; text-align: center; border: 1px solid rgba(255,255,255,0.14); background: radial-gradient(circle at center, rgba(255,255,255,0.11), rgba(255,255,255,0.018)); backdrop-filter: blur(10px); box-shadow: 0 0 56px rgba(255,255,255,0.05); z-index: 3; animation: studioFloat 5.8s ease-in-out infinite; }
+        .studio-node.you { left: 40%; top: 40%; }
+        .studio-node.other { left: 70%; top: 46%; animation-delay: -1.3s; }
+        .studio-summary { position: absolute; left: 24px; right: 24px; bottom: 24px; z-index: 3; display: grid; gap: 12px; }
+        .studio-summarycard { padding: 16px; border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.04); }
+        .studio-summarygrid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 10px; }
+
+        .studio-flow { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 20px; }
+        .studio-flowitem { padding: 22px; border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.03); display: grid; gap: 12px; }
+        .studio-flowitem strong { font-size: 34px; font-family: var(--font-display), serif; font-weight: 500; line-height: 1; }
+
+        .studio-trust { display: grid; grid-template-columns: minmax(0,1.1fr) minmax(0,0.9fr); gap: 20px; align-items: start; }
+        .studio-panel { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.03); padding: clamp(20px, 3vw, 34px); display: grid; gap: 14px; }
+        .studio-list { margin: 0; padding-left: 18px; line-height: 1.75; color: rgba(245,242,236,0.72); display: grid; gap: 10px; }
+
+        .studio-close { display: grid; gap: 20px; justify-items: start; max-width: 820px; }
+
+        @keyframes studioSweep { from { left: -28%; } to { left: 100%; } }
+        @keyframes studioFloat { 0%, 100% { transform: translate(-50%, -50%) translateY(0px); } 50% { transform: translate(-50%, -50%) translateY(-6px); } }
+
+        @media (max-width: 1120px) {
+          .studio-hero, .studio-flow, .studio-trust { grid-template-columns: 1fr; }
+          .studio-field { min-height: 900px; }
+          .studio-title { font-size: clamp(2.7rem, 11vw, 5.3rem); }
         }
-
-        .st-page::before {
-          content: "";
-          position: absolute;
-          inset: 0;
-          pointer-events: none;
-          opacity: 0.26;
-          background-image:
-            radial-gradient(circle at 18% 24%, rgba(255, 255, 255, 0.16) 0.7px, transparent 0.8px),
-            radial-gradient(circle at 74% 80%, rgba(255, 255, 255, 0.13) 0.7px, transparent 0.8px);
-          background-size: 3px 3px, 4px 4px;
-          mix-blend-mode: soft-light;
-          z-index: 0;
-        }
-
-        .st-shell {
-          position: relative;
-          z-index: 1;
-          width: min(1560px, 100%);
-          margin: 0 auto;
-          padding: 36px clamp(18px, 3.4vw, 48px) 120px;
-          display: grid;
-          gap: clamp(54px, 9vw, 118px);
-        }
-
-        .st-topbar {
-          display: flex;
-          justify-content: space-between;
-          align-items: flex-start;
-          gap: 18px;
-        }
-
-        .st-brand { display: grid; gap: 4px; }
-        .st-kicker {
-          font-size: 10px;
-          letter-spacing: 0.21em;
-          text-transform: uppercase;
-          color: rgba(245, 242, 236, 0.5);
-        }
-        .st-muted { color: rgba(245, 242, 236, 0.68); }
-
-        .st-nav { display: flex; gap: 10px; flex-wrap: wrap; }
-        .st-link {
-          color: #f5f2ec;
-          text-decoration: none;
-          font-size: 11px;
-          letter-spacing: 0.1em;
-          text-transform: uppercase;
-          padding: 9px 0;
-          border-bottom: 1px solid rgba(245, 242, 236, 0.22);
-          opacity: 0.8;
-          transition: opacity 160ms ease, border-color 160ms ease;
-        }
-        .st-link:hover { opacity: 1; border-color: rgba(245, 242, 236, 0.5); }
-
-        .st-hero {
-          display: grid;
-          grid-template-columns: minmax(0, 1.06fr) minmax(0, 0.94fr);
-          gap: clamp(28px, 5vw, 80px);
-          align-items: start;
-        }
-
-        .st-intro {
-          display: grid;
-          gap: clamp(32px, 4.4vw, 52px);
-          padding-top: clamp(28px, 7vw, 120px);
-          max-width: 760px;
-        }
-
-        .st-title {
-          margin: 0;
-          font-family: var(--font-display), serif;
-          font-size: clamp(3rem, 8.6vw, 7.8rem);
-          line-height: 0.84;
-          letter-spacing: -0.048em;
-          text-wrap: balance;
-          max-width: 13ch;
-        }
-
-        .st-lead {
-          margin: 0;
-          font-size: clamp(1rem, 1.6vw, 1.16rem);
-          line-height: 1.88;
-          max-width: 54ch;
-        }
-
-        .st-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
-        .st-btn {
-          text-decoration: none;
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          border-radius: 999px;
-          transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
-        }
-        .st-btn:hover { transform: translateY(-1px); }
-
-        .st-btn-primary {
-          background: linear-gradient(135deg, #faf6ee 0%, #e7d7b8 92%);
-          color: #090909;
-          font-weight: 600;
-          font-size: 13px;
-          letter-spacing: 0.06em;
-          text-transform: uppercase;
-          padding: 15px 24px;
-          box-shadow: 0 0 0 1px rgba(243, 231, 209, 0.2), 0 12px 32px rgba(10, 10, 10, 0.4);
-        }
-        .st-btn-secondary {
-          color: #f5f2ec;
-          border: 1px solid rgba(255, 255, 255, 0.26);
-          background: rgba(255, 255, 255, 0.03);
-          font-size: 12px;
-          letter-spacing: 0.09em;
-          text-transform: uppercase;
-          padding: 14px 20px;
-        }
-        .st-btn-tertiary {
-          color: rgba(245, 242, 236, 0.78);
-          font-size: 12px;
-          letter-spacing: 0.1em;
-          text-transform: uppercase;
-          padding: 10px 4px;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-        }
-
-        .st-quiet-note {
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
-          color: rgba(245, 242, 236, 0.44);
-        }
-
-        .st-field {
-          position: relative;
-          min-height: 760px;
-          padding-top: clamp(8px, 3vw, 40px);
-        }
-
-        .st-field::before {
-          content: "";
-          position: absolute;
-          right: -6%;
-          top: 15%;
-          width: 92%;
-          height: 74%;
-          border-radius: 46% 54% 50% 50%;
-          background:
-            radial-gradient(circle at 20% 24%, rgba(255, 255, 255, 0.1), transparent 44%),
-            radial-gradient(circle at 76% 66%, rgba(233, 214, 183, 0.16), transparent 48%),
-            linear-gradient(168deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.02));
-          filter: blur(0.2px);
-          opacity: 0.85;
-        }
-
-        .st-thread {
-          position: absolute;
-          left: 0;
-          top: 0;
-          width: min(420px, 88%);
-          display: grid;
-          gap: 14px;
-          z-index: 4;
-        }
-
-        .st-bubble {
-          padding: 16px 18px;
-          backdrop-filter: blur(14px);
-          border: 1px solid rgba(255, 255, 255, 0.14);
-          background: rgba(255, 255, 255, 0.038);
-          line-height: 1.72;
-          font-size: 14px;
-        }
-
-        .st-bubble.assistant {
-          margin-left: 42px;
-          background: linear-gradient(140deg, rgba(226, 207, 175, 0.21), rgba(255, 255, 255, 0.04));
-        }
-
-        .st-preview {
-          position: absolute;
-          inset: 118px 0 0 54px;
-          border-radius: 28px;
-          overflow: hidden;
-          border: 1px solid rgba(255, 255, 255, 0.1);
-          background:
-            radial-gradient(circle at 18% 28%, rgba(255, 255, 255, 0.08), transparent 34%),
-            radial-gradient(circle at 74% 42%, rgba(222, 201, 169, 0.14), transparent 40%),
-            linear-gradient(160deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015));
-        }
-
-        .st-scan {
-          position: absolute;
-          inset: 0;
-          opacity: 0.2;
-          background-image: linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-          background-size: 100% 36px;
-          animation: stScan 8s linear infinite;
-        }
-
-        .st-orbit {
-          position: absolute;
-          left: 55%;
-          top: 45%;
-          width: min(440px, 84%);
-          aspect-ratio: 1;
-          transform: translate(-50%, -50%);
-          border-radius: 50%;
-          border: 1px solid rgba(255, 255, 255, 0.15);
-        }
-
-        .st-orbit::before,
-        .st-orbit::after {
-          content: "";
-          position: absolute;
-          inset: 12%;
-          border-radius: 50%;
-          border: 1px solid rgba(255, 255, 255, 0.08);
-        }
-
-        .st-orbit::after { inset: 28%; }
-
-        .st-line {
-          position: absolute;
-          left: 56%;
-          top: 47%;
-          width: 340px;
-          height: 1px;
-          transform: translate(-50%, -50%);
-          background: linear-gradient(90deg, rgba(228, 210, 179, 0), rgba(228, 210, 179, 0.4), rgba(255, 255, 255, 0.68), rgba(228, 210, 179, 0.4), rgba(228, 210, 179, 0));
-        }
-
-        .st-line::after {
-          content: "";
-          position: absolute;
-          left: -28%;
-          top: -1px;
-          width: 24%;
-          height: 3px;
-          background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.78), transparent);
-          animation: stSweep 3.6s linear infinite;
-        }
-
-        .st-node {
-          position: absolute;
-          width: 170px;
-          aspect-ratio: 1;
-          border-radius: 50%;
-          border: 1px solid rgba(255, 255, 255, 0.18);
-          background: radial-gradient(circle at 50% 40%, rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.03));
-          display: grid;
-          place-items: center;
-          text-align: center;
-          z-index: 3;
-          box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
-        }
-
-        .st-node.you { left: 37%; top: 41%; transform: translate(-50%, -50%); }
-        .st-node.other { left: 73%; top: 47%; transform: translate(-50%, -50%); }
-
-        .st-summary {
-          position: absolute;
-          left: 24px;
-          right: 24px;
-          bottom: 22px;
-          padding: 18px 20px;
-          background: linear-gradient(180deg, rgba(6, 6, 6, 0.48), rgba(10, 10, 10, 0.72));
-          border-top: 1px solid rgba(255, 255, 255, 0.12);
-          z-index: 5;
-          display: grid;
-          gap: 9px;
-        }
-
-        .st-summary-title {
-          margin: 0;
-          font-family: var(--font-display), serif;
-          font-size: clamp(1.5rem, 3.1vw, 2rem);
-          line-height: 1;
-          letter-spacing: -0.02em;
-        }
-
-        .st-flow-wrap {
-          display: grid;
-          grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-          gap: clamp(22px, 5vw, 58px);
-          align-items: end;
-        }
-
-        .st-manifesto {
-          max-width: 520px;
-          display: grid;
-          gap: 18px;
-          padding-right: 20px;
-        }
-
-        .st-manifesto h2 {
-          margin: 0;
-          font-family: var(--font-display), serif;
-          font-size: clamp(2.1rem, 4.4vw, 4rem);
-          line-height: 0.9;
-          letter-spacing: -0.036em;
-          max-width: 12ch;
-        }
-
-        .st-flow {
-          display: grid;
-          gap: 0;
-          border-left: 1px solid rgba(255, 255, 255, 0.18);
-          padding-left: clamp(18px, 2vw, 28px);
-        }
-
-        .st-flow-item {
-          display: grid;
-          gap: 8px;
-          padding: 18px 0 20px;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-        }
-
-        .st-flow-item:last-child { border-bottom: 0; padding-bottom: 0; }
-
-        .st-flow-label {
-          font-size: 10px;
-          letter-spacing: 0.2em;
-          text-transform: uppercase;
-          color: rgba(245, 242, 236, 0.46);
-        }
-
-        @keyframes stSweep { from { left: -28%; } to { left: 106%; } }
-        @keyframes stScan {
-          from { transform: translateY(-6px); }
-          50% { transform: translateY(6px); }
-          to { transform: translateY(-6px); }
-        }
-
-        @media (max-width: 1180px) {
-          .st-hero,
-          .st-flow-wrap {
-            grid-template-columns: 1fr;
-          }
-
-          .st-intro { padding-top: 10px; max-width: 100%; }
-          .st-field { min-height: 800px; }
-          .st-preview { inset: 178px 0 0 0; }
-        }
-
         @media (max-width: 760px) {
-          .st-shell { padding: 24px 16px 90px; gap: 68px; }
-          .st-topbar { flex-direction: column; }
-          .st-title { font-size: clamp(2.4rem, 13.5vw, 4rem); }
-          .st-thread { position: relative; width: 100%; }
-          .st-bubble.assistant { margin-left: 24px; }
-          .st-field { min-height: 760px; }
-          .st-preview { inset: 168px 0 0 0; border-radius: 22px; }
-          .st-line { width: 220px; }
-          .st-node { width: 126px; }
-          .st-node.you { left: 35%; top: 44%; }
-          .st-node.other { left: 71%; top: 50%; }
-          .st-summary-title { font-size: 1.35rem; }
+          .studio-shell { padding-bottom: 88px; }
+          .studio-topbar { flex-direction: column; }
+          .studio-field { min-height: 980px; }
+          .studio-node { width: 146px; height: 146px; }
+          .studio-summarygrid { grid-template-columns: 1fr; }
         }
       `}</style>
 
-      <div className="st-page">
-        <div className="st-shell">
-          <header className="st-topbar">
-            <div className="st-brand">
-              <div className="st-kicker">Defrag</div>
-              <div>Studio</div>
+      <div className="studio-page">
+        <div className="studio-shell">
+          <header className="studio-topbar">
+            <div className="studio-brand">
+              <div className="studio-kicker">Defrag · Relationship intelligence</div>
+              <div>Premium studio for emotionally clear conversations</div>
             </div>
-
-            <nav className="st-nav">
-              <Link className="st-link" href="/signin">Sign in</Link>
-              <Link className="st-link" href="/signup">Create account</Link>
-              <Link className="st-link" href="/workspace">Workspace preview</Link>
+            <nav className="studio-nav">
+              <Link className="studio-navlink" href="/workspace">
+                Workspace
+              </Link>
+              <Link className="studio-navlink" href="/signin/studio">
+                Sign in
+              </Link>
+              <Link className="studio-navlink" href="/billing/studio">
+                Plans
+              </Link>
             </nav>
           </header>
 
-          <section className="st-hero">
-            <div className="st-intro">
-              <div style={{ display: "grid", gap: 22 }}>
-                <div className="st-kicker">Relationship intelligence, rendered clearly</div>
-                <h1 className="st-title">See what is happening between people.</h1>
-                <p className="st-lead st-muted">
-                  Defrag turns difficult relationship moments into calm, plain-language field reads so you can decide what to do next with steadiness.
-                </p>
+          <section className="studio-hero">
+            <div className="studio-left">
+              <div className="studio-kicker">Flagship relationship environment</div>
+              <h1 className="studio-title">See what may be happening between people, with calm clarity.</h1>
+              <p className="studio-copy studio-muted">
+                Defrag helps you read difficult relationship moments in plain language. The studio turns one hard interaction into a clear map,
+                a steadier understanding, and one practical next step.
+              </p>
+              <div className="studio-cta">
+                <Link className="studio-btn primary" href="/enter">
+                  Open Defrag
+                </Link>
+                <Link className="studio-btn secondary" href="/signup/studio">
+                  Create account
+                </Link>
+                <Link className="studio-btn tertiary" href="/workspace">
+                  Preview workspace
+                </Link>
               </div>
-
-              <div style={{ display: "grid", gap: 15 }}>
-                <div className="st-actions">
-                  <Link className="st-btn st-btn-primary" href="/enter">Open Defrag</Link>
-                  <Link className="st-btn st-btn-secondary" href="/start">Start baseline</Link>
-                  <Link className="st-btn st-btn-tertiary" href="/billing">View plans</Link>
-                </div>
-
-                <div className="st-quiet-note">Built for emotional safety • plain-language first • desktop + mobile</div>
-              </div>
+              <div className="studio-kicker">Built for emotional safety · plain-language guidance · high-trust material quality</div>
             </div>
 
-            <div className="st-field">
-              <div className="st-thread">
-                <div className="st-bubble user">
-                  <div className="st-kicker" style={{ marginBottom: 8 }}>You</div>
+            <section className="studio-field">
+              <div className="studio-thread">
+                <div className="studio-bubble">
+                  <div className="studio-kicker" style={{ marginBottom: 8 }}>
+                    You
+                  </div>
                   I want to talk to my mom tonight, but I think we may miss each other again.
                 </div>
-                <div className="st-bubble assistant">
-                  <div className="st-kicker" style={{ marginBottom: 8 }}>Defrag</div>
-                  This may be a moment where both people care, but pressure is distorting how each side hears the other.
+                <div className="studio-bubble assistant">
+                  <div className="studio-kicker" style={{ marginBottom: 8 }}>
+                    Defrag
+                  </div>
+                  This may be a moment where both of you care about the relationship, but may react in ways that make each other harder to hear.
                 </div>
               </div>
 
-              <div className="st-preview">
-                <div className="st-scan" />
-                <div className="st-orbit" />
-                <div className="st-line" />
-
-                <div className="st-node you">
-                  <div className="st-kicker" style={{ fontSize: 10 }}>self</div>
-                  <div style={{ fontSize: 28, fontFamily: "var(--font-display), serif" }}>You</div>
-                  <div className="st-muted" style={{ fontSize: 12 }}>trying to be heard</div>
+              <div className="studio-linkline" />
+              <div className="studio-node you">
+                <div className="studio-kicker" style={{ fontSize: 10 }}>
+                  self
                 </div>
-
-                <div className="st-node other">
-                  <div className="st-kicker" style={{ fontSize: 10 }}>family</div>
-                  <div style={{ fontSize: 28, fontFamily: "var(--font-display), serif" }}>Mother</div>
-                  <div className="st-muted" style={{ fontSize: 12 }}>guarded</div>
+                <div style={{ fontSize: 30, fontFamily: "var(--font-display), serif" }}>You</div>
+                <div className="studio-muted" style={{ fontSize: 13 }}>
+                  trying to be heard
                 </div>
+              </div>
+              <div className="studio-node other">
+                <div className="studio-kicker" style={{ fontSize: 10 }}>
+                  family
+                </div>
+                <div style={{ fontSize: 30, fontFamily: "var(--font-display), serif" }}>Mother</div>
+                <div className="studio-muted" style={{ fontSize: 13 }}>
+                  guarded and tired
+                </div>
+              </div>
 
-                <div className="st-summary">
-                  <div className="st-kicker">Live field preview</div>
-                  <h2 className="st-summary-title">What may be happening</h2>
-                  <div className="st-muted" style={{ lineHeight: 1.72 }}>
-                    Both people may be trying to protect the relationship, but the pace of the exchange is making each side harder to hear.
+              <div className="studio-summary">
+                <div className="studio-summarycard">
+                  <div className="studio-kicker">Field summary</div>
+                  <div style={{ fontSize: 26, fontFamily: "var(--font-display), serif", marginTop: 6 }}>What may be happening right now</div>
+                  <div className="studio-muted" style={{ lineHeight: 1.72, marginTop: 8 }}>
+                    Both people may want connection, but pressure may be steering tone faster than either person intends.
                   </div>
                 </div>
+                <div className="studio-summarygrid">
+                  {[
+                    "See the central pattern more clearly.",
+                    "Open a focused view of the other side.",
+                    "Choose one lower-pressure next move.",
+                  ].map((item) => (
+                    <div key={item} className="studio-summarycard" style={{ lineHeight: 1.68 }}>
+                      {item}
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
+            </section>
           </section>
 
-          <section className="st-flow-wrap">
-            <article className="st-manifesto">
-              <div className="st-kicker">How the flow feels</div>
-              <h2>From baseline to live field, with one coherent rhythm.</h2>
-              <p className="st-muted" style={{ margin: 0, lineHeight: 1.84 }}>
-                The experience is designed to reduce noise. You begin with baseline context, then move into one interaction, compare perspectives, and leave with one grounded next move.
-              </p>
-            </article>
-
-            <aside className="st-flow">
-              {FLOW.map((item) => (
-                <div key={item.label} className="st-flow-item">
-                  <div className="st-flow-label">{item.label}</div>
-                  <div className="st-muted" style={{ lineHeight: 1.75 }}>{item.body}</div>
+          <section className="studio-flow">
+            {FLOW_STEPS.map((step, index) => (
+              <article key={step.title} className="studio-flowitem">
+                <div className="studio-kicker">Step {index + 1}</div>
+                <strong>{step.title}</strong>
+                <div className="studio-muted" style={{ lineHeight: 1.74 }}>
+                  {step.body}
                 </div>
-              ))}
-            </aside>
+              </article>
+            ))}
+          </section>
+
+          <section className="studio-trust">
+            <article className="studio-panel">
+              <div className="studio-kicker">Trust and safety</div>
+              <div style={{ fontSize: 38, lineHeight: 0.96, fontFamily: "var(--font-display), serif" }}>Built to reduce emotional friction, not increase it.</div>
+              <div className="studio-muted" style={{ lineHeight: 1.8 }}>
+                Defrag is designed for steady interpretation, plain-language insight, and practical next steps. It helps you slow down reaction cycles without
+                forcing clinical framing or manipulative tactics.
+              </div>
+            </article>
+            <article className="studio-panel">
+              <div className="studio-kicker">What stays consistent</div>
+              <ul className="studio-list">
+                <li>Simple language you can use in real conversations.</li>
+                <li>Guidance that protects dignity for both people.</li>
+                <li>A consistent environment across intake, workspace, and account surfaces.</li>
+              </ul>
+            </article>
+          </section>
+
+          <section className="studio-close">
+            <div className="studio-kicker">Start when you are ready</div>
+            <div style={{ fontSize: 48, lineHeight: 0.92, fontFamily: "var(--font-display), serif" }}>Enter the studio and open one relationship moment clearly.</div>
+            <div className="studio-cta">
+              <Link className="studio-btn primary" href="/enter">
+                Open Defrag
+              </Link>
+              <Link className="studio-btn secondary" href="/signin/studio">
+                Sign in to continue
+              </Link>
+            </div>
           </section>
         </div>
       </div>

--- a/apps/web/src/app/workspace/page.tsx
+++ b/apps/web/src/app/workspace/page.tsx
@@ -94,8 +94,7 @@ type StoryCanvasView = {
   rewritePath: RewritePath | null;
 };
 
-const INITIAL_MESSAGE =
-  "I want to talk to my mom tonight, but I think we may end up missing each other again.";
+const INITIAL_MESSAGE = "I want to talk to my mom tonight, but I think we may end up missing each other again.";
 
 export default function WorkspacePage() {
   const [message, setMessage] = useState(INITIAL_MESSAGE);
@@ -114,9 +113,7 @@ export default function WorkspacePage() {
     const relationshipLabel =
       result?.field_update.participants.map((participant) => participant.name).join(" and ") || "You and your mother";
 
-    const sharedGoal =
-      result?.assistant_message.next_steps[0] ??
-      "move the conversation toward clarity, steadiness, and a practical next step";
+    const sharedGoal = result?.assistant_message.next_steps[0] ?? "move the conversation toward clarity, steadiness, and a practical next step";
 
     const scene = buildScene(
       {
@@ -193,227 +190,239 @@ export default function WorkspacePage() {
   return (
     <main style={{ minHeight: "100vh", background: "#050505", color: "#f6f3ee" }}>
       <style>{`
-        .ws-shell { display:grid; grid-template-columns: 380px minmax(0,1fr) 380px; min-height:100vh; }
-        .ws-col { border-right:1px solid rgba(255,255,255,0.08); }
-        .ws-col:last-child { border-right:none; }
-        .ws-left, .ws-center, .ws-right { display:grid; }
-        .ws-left { grid-template-rows:auto auto 1fr; }
-        .ws-center { grid-template-rows:auto 1fr auto; }
-        .ws-right { align-content:start; }
-        .ws-block { padding:22px; }
-        .ws-header { border-bottom:1px solid rgba(255,255,255,0.08); }
-        .ws-kicker { font-size:11px; letter-spacing:0.18em; text-transform:uppercase; color:rgba(246,243,238,0.46); }
-        .ws-muted { color: rgba(246,243,238,0.62); }
-        .ws-title { margin:0; font-size:34px; line-height:0.98; font-family: var(--font-display), serif; }
-        .ws-card { border:1px solid rgba(255,255,255,0.09); background: rgba(255,255,255,0.02); }
-        .ws-textarea { width:100%; min-height:140px; resize:vertical; background:#0a0a0a; color:#f6f3ee; border:1px solid rgba(255,255,255,0.12); padding:14px; line-height:1.65; }
-        .ws-btn { background:#f6f3ee; color:#050505; border:none; padding:12px 16px; font-weight:600; cursor:pointer; }
-        .ws-btn.secondary { background:transparent; color:#f6f3ee; border:1px solid rgba(255,255,255,0.12); }
-        .ws-thread { display:grid; gap:12px; padding:0 22px 22px; align-content:start; }
-        .ws-bubble { padding:14px 16px; border:1px solid rgba(255,255,255,0.08); line-height:1.7; }
-        .ws-bubble.user { background: rgba(255,255,255,0.03); margin-left:auto; max-width:94%; }
-        .ws-bubble.assistant { background: rgba(214,195,161,0.08); max-width:94%; }
-        .ws-canvas { position:relative; overflow:hidden; min-height:560px; }
-        .ws-canvas::before { content:""; position:absolute; inset:0; background:radial-gradient(circle at 50% 50%, rgba(214,195,161,0.06), transparent 40%); }
-        .ws-canvas::after { content:""; position:absolute; inset:0; background-image: linear-gradient(rgba(255,255,255,0.018) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.018) 1px, transparent 1px); background-size:32px 32px; opacity:0.12; }
-        .ws-node { position:absolute; width:136px; height:136px; border-radius:999px; border:1px solid rgba(255,255,255,0.16); display:flex; align-items:center; justify-content:center; flex-direction:column; backdrop-filter: blur(8px); background: rgba(255,255,255,0.02); z-index:2; }
-        .ws-edge { position:absolute; left:50%; top:50%; width:240px; height:1px; background: linear-gradient(90deg, rgba(255,255,255,0.1), rgba(255,255,255,0.3), rgba(255,255,255,0.1)); transform: translate(-50%, -50%); z-index:1; }
-        .ws-panel-list { display:grid; gap:12px; padding:22px; }
-        .ws-tag { font-size:10px; letter-spacing:0.14em; text-transform:uppercase; color:rgba(246,243,238,0.5); }
-        .ws-list { margin:0; padding-left:18px; display:grid; gap:8px; line-height:1.55; color:rgba(246,243,238,0.82); }
-        @media (max-width: 1180px) {
+        .ws-page { min-height: 100vh; background: radial-gradient(980px 660px at 68% 4%, rgba(214,195,161,0.1), transparent 68%), radial-gradient(760px 520px at 14% 18%, rgba(255,255,255,0.05), transparent 70%), linear-gradient(162deg, #080808, #050505 52%, #090909); }
+        .ws-shell { width: min(1640px, 100%); margin: 0 auto; padding: 20px clamp(14px, 2.2vw, 32px) 28px; display: grid; grid-template-columns: 380px minmax(0,1fr) 400px; gap: 14px; min-height: 100vh; }
+        .ws-col { border: 1px solid rgba(255,255,255,0.09); background: rgba(255,255,255,0.025); backdrop-filter: blur(10px); min-height: calc(100vh - 48px); }
+        .ws-block { padding: 20px; }
+        .ws-divider { border-top: 1px solid rgba(255,255,255,0.08); }
+        .ws-kicker { font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(246,243,238,0.44); }
+        .ws-muted { color: rgba(246,243,238,0.66); }
+        .ws-title { margin: 0; font-family: var(--font-display), serif; font-size: 36px; line-height: 0.94; }
+
+        .ws-textarea { width: 100%; min-height: 150px; resize: vertical; background: rgba(0,0,0,0.34); color: #f6f3ee; border: 1px solid rgba(255,255,255,0.12); padding: 14px; line-height: 1.68; }
+        .ws-textarea:focus { outline: 1px solid rgba(214,195,161,0.36); border-color: rgba(214,195,161,0.4); }
+        .ws-row { display: flex; gap: 10px; flex-wrap: wrap; }
+        .ws-btn { border: 1px solid rgba(255,255,255,0.1); background: #f6f3ee; color: #050505; padding: 12px 15px; font-weight: 600; cursor: pointer; }
+        .ws-btn.secondary { background: rgba(255,255,255,0.03); color: #f6f3ee; }
+
+        .ws-thread { display: grid; gap: 10px; }
+        .ws-bubble { padding: 14px; border: 1px solid rgba(255,255,255,0.1); line-height: 1.68; background: rgba(255,255,255,0.035); }
+        .ws-bubble.user { margin-left: auto; max-width: 95%; }
+        .ws-bubble.assistant { max-width: 95%; background: linear-gradient(145deg, rgba(214,195,161,0.18), rgba(255,255,255,0.035)); }
+
+        .ws-center { display: grid; grid-template-rows: auto minmax(520px, 1fr) auto; }
+        .ws-canvas { position: relative; overflow: hidden; margin: 0 20px 20px; border: 1px solid rgba(255,255,255,0.1); background: radial-gradient(circle at 24% 24%, rgba(255,255,255,0.08), transparent 34%), radial-gradient(circle at 72% 68%, rgba(214,195,161,0.14), transparent 44%), linear-gradient(168deg, rgba(255,255,255,0.04), rgba(255,255,255,0.015)); }
+        .ws-canvas::after { content: ''; position: absolute; inset: 0; opacity: 0.14; background-image: linear-gradient(rgba(255,255,255,0.02) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px); background-size: 32px 32px; }
+        .ws-edge { position: absolute; left: 50%; top: 50%; width: 250px; height: 2px; transform: translate(-50%, -50%); background: linear-gradient(90deg, rgba(214,195,161,0), rgba(214,195,161,0.34), rgba(255,255,255,0.7), rgba(214,195,161,0.34), rgba(214,195,161,0)); z-index: 2; }
+        .ws-node { position: absolute; width: 140px; height: 140px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.16); background: radial-gradient(circle at center, rgba(255,255,255,0.1), rgba(255,255,255,0.02)); display: grid; place-items: center; text-align: center; z-index: 3; box-shadow: 0 0 50px rgba(214,195,161,0.08); }
+        .ws-summary { position: absolute; left: 18px; right: 18px; bottom: 18px; z-index: 3; border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.04); padding: 14px; }
+
+        .ws-steps { margin: 0 20px 20px; display: grid; gap: 10px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+        .ws-step { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.03); padding: 14px; line-height: 1.64; }
+
+        .ws-side-list { padding: 20px; display: grid; gap: 12px; align-content: start; }
+        .ws-card { border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.032); padding: 14px; display: grid; gap: 8px; }
+        .ws-list { margin: 0; padding-left: 18px; display: grid; gap: 8px; line-height: 1.6; color: rgba(246,243,238,0.82); }
+        .ws-tag { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(246,243,238,0.52); }
+
+        @media (max-width: 1320px) {
           .ws-shell { grid-template-columns: 360px minmax(0,1fr); }
-          .ws-right { border-top:1px solid rgba(255,255,255,0.08); grid-column:1 / -1; }
-          .ws-panel-list { grid-template-columns: repeat(2, minmax(0,1fr)); display:grid; }
+          .ws-right { grid-column: 1 / -1; min-height: auto; }
+          .ws-side-list { grid-template-columns: repeat(2, minmax(0,1fr)); }
         }
-        @media (max-width: 840px) {
+        @media (max-width: 900px) {
           .ws-shell { grid-template-columns: 1fr; }
-          .ws-col { border-right:none; border-bottom:1px solid rgba(255,255,255,0.08); }
-          .ws-panel-list { grid-template-columns: 1fr; }
-          .ws-canvas { min-height:420px; }
+          .ws-col { min-height: auto; }
+          .ws-side-list { grid-template-columns: 1fr; }
+          .ws-canvas { min-height: 420px; }
         }
       `}</style>
 
-      <div className="ws-shell">
-        <section className="ws-col ws-left">
-          <div className="ws-block ws-header" style={{ display: "grid", gap: 10 }}>
-            <div className="ws-kicker">Defrag workspace</div>
-            <h1 className="ws-title">Relationship workspace</h1>
-            <p className="ws-muted" style={{ margin: 0, lineHeight: 1.65 }}>
-              Bring your baseline into this space to read one relationship moment clearly and choose a constructive next step.
-            </p>
-          </div>
-
-          <div className="ws-block" style={{ display: "grid", gap: 12 }}>
-            <div className="ws-kicker">Describe one moment</div>
-            <textarea className="ws-textarea" value={message} onChange={(e) => setMessage(e.target.value)} />
-            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-              <button className="ws-btn" onClick={interpret} disabled={loading}>
-                {loading ? "Reading the moment..." : "Analyze this moment"}
-              </button>
-              <button className="ws-btn secondary" onClick={() => setMessage(INITIAL_MESSAGE)}>
-                Reset example
-              </button>
+      <div className="ws-page">
+        <div className="ws-shell">
+          <section className="ws-col">
+            <div className="ws-block" style={{ display: "grid", gap: 10 }}>
+              <div className="ws-kicker">Defrag workspace</div>
+              <h1 className="ws-title">Relationship environment</h1>
+              <p className="ws-muted" style={{ margin: 0, lineHeight: 1.72 }}>
+                Bring one difficult moment into view, read it clearly, then choose a practical next move.
+              </p>
             </div>
-          </div>
 
-          <div style={{ display: "grid", gap: 12 }}>
-            <div className="ws-block ws-header" style={{ paddingTop: 14, paddingBottom: 14 }}>
-              <div className="ws-kicker">Conversation thread</div>
+            <div className="ws-divider ws-block" style={{ display: "grid", gap: 12 }}>
+              <div className="ws-kicker">Describe one moment</div>
+              <textarea className="ws-textarea" value={message} onChange={(e) => setMessage(e.target.value)} />
+              <div className="ws-row">
+                <button className="ws-btn" onClick={interpret} disabled={loading}>
+                  {loading ? "Reading the moment..." : "Analyze this moment"}
+                </button>
+                <button className="ws-btn secondary" onClick={() => setMessage(INITIAL_MESSAGE)}>
+                  Reset example
+                </button>
+              </div>
             </div>
-            <div className="ws-thread">
-              {transcript.length === 0 ? (
-                <div className="ws-card" style={{ padding: 16 }}>
-                  <div className="ws-muted">Run your first read to open the thread, then compare it with your baseline guidance.</div>
-                </div>
-              ) : (
-                transcript.map((entry, index) => (
-                  <div key={`${entry.role}-${index}`} className={`ws-bubble ${entry.role}`}>
-                    <div className="ws-kicker" style={{ marginBottom: 8 }}>
-                      {entry.role === "user" ? "You" : "Defrag"}
-                    </div>
-                    <div>{entry.body}</div>
+
+            <div className="ws-divider ws-block" style={{ display: "grid", gap: 10 }}>
+              <div className="ws-kicker">Thread</div>
+              <div className="ws-thread">
+                {transcript.length === 0 ? (
+                  <div className="ws-bubble">
+                    <div className="ws-muted">Run your first read to open a plain-language thread of what may be happening.</div>
                   </div>
-                ))
+                ) : (
+                  transcript.map((entry, index) => (
+                    <div key={`${entry.role}-${index}`} className={`ws-bubble ${entry.role}`}>
+                      <div className="ws-kicker" style={{ marginBottom: 8 }}>
+                        {entry.role === "user" ? "You" : "Defrag"}
+                      </div>
+                      {entry.body}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section className="ws-col ws-center">
+            <div className="ws-block" style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "end" }}>
+              <div style={{ display: "grid", gap: 8 }}>
+                <div className="ws-kicker">Live field</div>
+                <div style={{ fontSize: 34, lineHeight: 0.94, fontFamily: "var(--font-display), serif" }}>Read the interaction clearly</div>
+              </div>
+              <div className="ws-card" style={{ minWidth: 240 }}>
+                <div className="ws-kicker">Current pattern</div>
+                <div style={{ marginTop: 6 }}>{result?.field_update.field_state.dominant_pattern ?? "Waiting for first read"}</div>
+              </div>
+            </div>
+
+            <div className="ws-canvas">
+              {result ? (
+                <>
+                  <div className="ws-edge" />
+                  {result.field_update.visual_state.nodes.map((node) => (
+                    <div
+                      key={node.id}
+                      className="ws-node"
+                      style={{
+                        left: `${node.x * 100}%`,
+                        top: `${node.y * 100}%`,
+                        transform: `translate(-50%, -50%) scale(${node.size})`,
+                      }}
+                    >
+                      <div className="ws-kicker" style={{ fontSize: 10 }}>
+                        {node.role ?? "person"}
+                      </div>
+                      <div style={{ fontSize: 26, fontFamily: "var(--font-display), serif" }}>{node.label}</div>
+                      <div className="ws-muted" style={{ fontSize: 12 }}>
+                        {node.state}
+                      </div>
+                    </div>
+                  ))}
+                  <div className="ws-summary">
+                    <div className="ws-kicker">Field reading</div>
+                    <div style={{ fontSize: 22, fontFamily: "var(--font-display), serif", marginTop: 4 }}>{result.assistant_message.title}</div>
+                    <div className="ws-muted" style={{ lineHeight: 1.68, marginTop: 6 }}>
+                      {result.field_update.thread.summary}
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", padding: 30 }}>
+                  <div style={{ display: "grid", gap: 10, textAlign: "center", maxWidth: 520 }}>
+                    <div className="ws-kicker">Field preview</div>
+                    <div style={{ fontSize: 32, lineHeight: 0.94, fontFamily: "var(--font-display), serif" }}>Your interaction map appears here</div>
+                    <div className="ws-muted" style={{ lineHeight: 1.74 }}>
+                      Analyze one moment to map people, pressure shifts, and a calmer direction for the conversation.
+                    </div>
+                  </div>
+                </div>
               )}
             </div>
-          </div>
-        </section>
 
-        <section className="ws-col ws-center">
-          <div className="ws-block ws-header" style={{ display: "flex", justifyContent: "space-between", alignItems: "end", gap: 12 }}>
-            <div style={{ display: "grid", gap: 8 }}>
-              <div className="ws-kicker">Live field</div>
-              <h2 style={{ margin: 0, fontSize: 30, lineHeight: 1.08 }}>Read the interaction clearly</h2>
-            </div>
-            <div className="ws-card" style={{ padding: "10px 12px", minWidth: 220 }}>
-              <div className="ws-kicker">Current pattern</div>
-              <div style={{ marginTop: 6 }}>{result?.field_update.field_state.dominant_pattern ?? "Waiting for first read"}</div>
-            </div>
-          </div>
-
-          <div className="ws-canvas ws-card">
-            {result ? (
-              <>
-                <div className="ws-edge" />
-                {result.field_update.visual_state.nodes.map((node) => (
-                  <div
-                    key={node.id}
-                    className="ws-node"
-                    style={{
-                      left: `${node.x * 100}%`,
-                      top: `${node.y * 100}%`,
-                      transform: `translate(-50%, -50%) scale(${node.size})`,
-                    }}
-                  >
-                    <div className="ws-kicker" style={{ fontSize: 10 }}>{node.role ?? "person"}</div>
-                    <div style={{ fontSize: 24, fontFamily: "var(--font-display), serif" }}>{node.label}</div>
-                    <div className="ws-muted" style={{ fontSize: 12 }}>{node.state}</div>
-                  </div>
-                ))}
-                <div style={{ position: "absolute", left: 22, right: 22, bottom: 22, zIndex: 3 }} className="ws-card">
-                  <div style={{ padding: 14, display: "grid", gap: 8 }}>
-                    <div className="ws-kicker">Field reading</div>
-                    <div style={{ fontSize: 20, fontFamily: "var(--font-display), serif" }}>{result.assistant_message.title}</div>
-                    <div className="ws-muted" style={{ lineHeight: 1.65 }}>{result.field_update.thread.summary}</div>
-                  </div>
-                </div>
-              </>
-            ) : (
-              <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", padding: 32 }}>
-                <div style={{ maxWidth: 520, textAlign: "center", display: "grid", gap: 10 }}>
-                  <div className="ws-kicker">Field preview</div>
-                  <div style={{ fontSize: 28, fontFamily: "var(--font-display), serif" }}>Your interaction map appears here</div>
-                  <div className="ws-muted" style={{ lineHeight: 1.7 }}>
-                    Run your first read to map people, pressure shifts, and where the conversation may open toward repair.
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-
-          <div className="ws-block" style={{ display: "grid", gap: 10 }}>
-            <div className="ws-kicker">What could help next</div>
-            <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+            <div className="ws-steps">
               {(result?.assistant_message.next_steps ?? [
                 "Start with what you want more of, not only what feels hard.",
                 "Keep the first step small enough that it can be heard.",
                 "If the moment is heated, create a little more room first.",
               ]).map((step) => (
-                <div key={step} className="ws-card" style={{ padding: 14, lineHeight: 1.6 }}>
+                <div key={step} className="ws-step">
                   {step}
                 </div>
               ))}
             </div>
-          </div>
-        </section>
+          </section>
 
-        <aside className="ws-col ws-right">
-          <div className="ws-block ws-header" style={{ display: "grid", gap: 8 }}>
-            <div className="ws-kicker">Story Canvas</div>
-            <h2 style={{ margin: 0, fontSize: 26 }}>{storyCanvas.scene.title}</h2>
-            <p className="ws-muted" style={{ margin: 0, lineHeight: 1.65 }}>{storyCanvas.scene.plainLanguageOverlay}</p>
-            <div className="ws-tag" style={{ marginTop: 2 }}>
-              Grammar: {storyCanvas.scene.grammarId}
+          <aside className="ws-col ws-right">
+            <div className="ws-block" style={{ display: "grid", gap: 8 }}>
+              <div className="ws-kicker">Story Canvas</div>
+              <h2 style={{ margin: 0, fontSize: 28, lineHeight: 1.04 }}>{storyCanvas.scene.title}</h2>
+              <p className="ws-muted" style={{ margin: 0, lineHeight: 1.7 }}>
+                {storyCanvas.scene.plainLanguageOverlay}
+              </p>
+              <div className="ws-tag">Grammar: {storyCanvas.scene.grammarId}</div>
             </div>
-          </div>
 
-          <div className="ws-panel-list">
-            <section className="ws-card" style={{ padding: 14, display: "grid", gap: 10 }}>
-              <div className="ws-kicker">Story beats</div>
-              <ol className="ws-list">
-                {storyCanvas.scene.beats.map((beat) => (
-                  <li key={beat.id}>
-                    <div style={{ display: "grid", gap: 6 }}>
-                      <div>
-                        <strong>{beat.title}.</strong> {beat.selectedOverlay}
+            <div className="ws-divider ws-side-list">
+              <section className="ws-card">
+                <div className="ws-kicker">Story beats</div>
+                <ol className="ws-list">
+                  {storyCanvas.scene.beats.map((beat) => (
+                    <li key={beat.id}>
+                      <div style={{ display: "grid", gap: 6 }}>
+                        <div>
+                          <strong>{beat.title}.</strong> {beat.selectedOverlay}
+                        </div>
+                        <div className="ws-tag">Focus: {beat.focus}</div>
+                        <div className="ws-muted">{beat.constructiveFrame}</div>
                       </div>
-                      <div className="ws-tag">Focus: {beat.focus}</div>
-                      <div className="ws-muted">{beat.constructiveFrame}</div>
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            </section>
-
-            <section className="ws-card" style={{ padding: 14, display: "grid", gap: 10 }}>
-              <div className="ws-kicker">Annotations</div>
-              <ul className="ws-list" style={{ paddingLeft: 16 }}>
-                {storyCanvas.annotations.map((annotation) => (
-                  <li key={annotation.id}>
-                    <span className="ws-tag" style={{ marginRight: 8 }}>{annotation.category}</span>
-                    {annotation.message}
-                  </li>
-                ))}
-              </ul>
-            </section>
-
-            {storyCanvas.rewritePath ? (
-              <section className="ws-card" style={{ padding: 14, display: "grid", gap: 10 }}>
-                <div className="ws-kicker">Constructive rewrite</div>
-                <div style={{ fontWeight: 600 }}>{storyCanvas.rewritePath.title}</div>
-                <div className="ws-muted" style={{ lineHeight: 1.6 }}>
-                  <strong style={{ color: "#f6f3ee" }}>Before:</strong> {storyCanvas.rewritePath.before}
-                </div>
-                <div className="ws-muted" style={{ lineHeight: 1.6 }}>
-                  <strong style={{ color: "#f6f3ee" }}>After:</strong> {storyCanvas.rewritePath.after}
-                </div>
-                <div className="ws-tag">{storyCanvas.rewritePath.rationale}</div>
+                    </li>
+                  ))}
+                </ol>
               </section>
-            ) : null}
 
-            {placeholderPanels.map((panel) => (
-              <section key={panel.id} className="ws-card" style={{ padding: 14, display: "grid", gap: 8 }}>
-                <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "center" }}>
-                  <div className="ws-kicker">{panel.subtitle}</div>
-                  <div className="ws-tag">{panel.state}</div>
-                </div>
-                <div style={{ fontSize: 20, fontFamily: "var(--font-display), serif" }}>{panel.title}</div>
-                <div className="ws-muted" style={{ lineHeight: 1.6 }}>{panel.body}</div>
+              <section className="ws-card">
+                <div className="ws-kicker">Annotations</div>
+                <ul className="ws-list" style={{ paddingLeft: 16 }}>
+                  {storyCanvas.annotations.map((annotation) => (
+                    <li key={annotation.id}>
+                      <span className="ws-tag" style={{ marginRight: 8 }}>
+                        {annotation.category}
+                      </span>
+                      {annotation.message}
+                    </li>
+                  ))}
+                </ul>
               </section>
-            ))}
-          </div>
-        </aside>
+
+              {storyCanvas.rewritePath ? (
+                <section className="ws-card">
+                  <div className="ws-kicker">Constructive rewrite</div>
+                  <div style={{ fontWeight: 600 }}>{storyCanvas.rewritePath.title}</div>
+                  <div className="ws-muted" style={{ lineHeight: 1.6 }}>
+                    <strong style={{ color: "#f6f3ee" }}>Before:</strong> {storyCanvas.rewritePath.before}
+                  </div>
+                  <div className="ws-muted" style={{ lineHeight: 1.6 }}>
+                    <strong style={{ color: "#f6f3ee" }}>After:</strong> {storyCanvas.rewritePath.after}
+                  </div>
+                  <div className="ws-tag">{storyCanvas.rewritePath.rationale}</div>
+                </section>
+              ) : null}
+
+              {placeholderPanels.map((panel) => (
+                <section key={panel.id} className="ws-card">
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "center" }}>
+                    <div className="ws-kicker">{panel.subtitle}</div>
+                    <div className="ws-tag">{panel.state}</div>
+                  </div>
+                  <div style={{ fontSize: 21, lineHeight: 1.04, fontFamily: "var(--font-display), serif" }}>{panel.title}</div>
+                  <div className="ws-muted" style={{ lineHeight: 1.64 }}>
+                    {panel.body}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </aside>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
### Motivation
- Modernize the visual language and layout across public and authenticated surfaces to provide a more consistent, responsive studio and workspace experience.
- Clarify copy and CTAs to make onboarding and account flows more direct and contextual.
- Simplify page shells by moving away from a shared `AppShell` to inline page layouts and tighten error/flow handling in onboarding and auth flows.

### Description
- Reworked page layouts and CSS across multiple pages including `apps/web/src/app/intake/page.tsx`, `onboarding/page.tsx`, `signin/studio/page.tsx`, `signup/studio/page.tsx`, `studio/page.tsx`, and `workspace/page.tsx` to use new class names and updated responsive styles and background treatments. 
- Rewrote a number of UI sections and copy: updated headings, kicker text, button labels and nav links (e.g. new studio/signup/signin routes and plan/workspace link targets) and replaced previous style blocks with refreshed, consistent design tokens and semantics. 
- Replaced use of `AppShell` in onboarding with an inline layout and improved the onboarding submit flow to better scope the Supabase user fetch/update and error handling.
- Minor code cleanups: renamed the `FLOW` constant to `FLOW_STEPS`, normalized string quoting, adjusted form initial states, and kept existing API calls (`/api/test-baseline`, `/api/workspace/interpret`) intact.

### Testing
- Built the app with `pnpm build` which completed successfully. 
- Ran linting with `pnpm lint` and fixed reported style issues, and the lint step passed. 
- Ran the test suite with `pnpm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3246e8984833281fa82c703e4aa07)