### PR TITLE
Phase 15: polish Story Canvas in /workspace (progressive reveal)

### DIFF
--- a/apps/web/src/app/workspace/page.tsx
+++ b/apps/web/src/app/workspace/page.tsx
@@ -100,9 +100,10 @@ export default function WorkspacePage() {
   const [message, setMessage] = useState(INITIAL_MESSAGE);
   const [result, setResult] = useState<WorkspaceResponse | null>(null);
   const [loading, setLoading] = useState(false);
-  const [showAllBeats, setShowAllBeats] = useState(false);
-  const [showAllAnnotations, setShowAllAnnotations] = useState(false);
-  const [showRewriteDetails, setShowRewriteDetails] = useState(false);
+  const [visibleBeatCount, setVisibleBeatCount] = useState(2);
+  const [visibleAnnotationCount, setVisibleAnnotationCount] = useState(3);
+  const [showRewriteBeforeAfter, setShowRewriteBeforeAfter] = useState(false);
+  const [showRewriteRationale, setShowRewriteRationale] = useState(false);
 
   const transcript = useMemo(() => {
     if (!result) return [];
@@ -231,13 +232,15 @@ export default function WorkspacePage() {
         .ws-rail-card { padding: 16px; gap: 10px; }
         .ws-panel-head { display: flex; justify-content: space-between; gap: 10px; align-items: baseline; }
         .ws-section-intro { margin: 0; color: rgba(246,243,238,0.72); line-height: 1.68; font-size: 14px; }
-        .ws-story-list { padding-left: 16px; gap: 10px; }
-        .ws-story-item { border-left: 1px solid rgba(255,255,255,0.12); padding-left: 12px; margin-left: 2px; display: grid; gap: 7px; }
-        .ws-reveal-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+        .ws-story-list { padding-left: 16px; gap: 12px; margin: 0; }
+        .ws-story-item { border-left: 1px solid rgba(255,255,255,0.12); padding: 2px 0 2px 12px; margin-left: 2px; display: grid; gap: 8px; }
+        .ws-reveal-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap; padding-top: 2px; }
         .ws-reveal-btn { border: 1px solid rgba(214,195,161,0.36); background: rgba(214,195,161,0.08); color: #f6f3ee; padding: 6px 10px; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; cursor: pointer; transition: background 120ms ease, border-color 120ms ease; }
         .ws-reveal-btn:hover { background: rgba(214,195,161,0.16); border-color: rgba(214,195,161,0.54); }
         .ws-reveal-btn.quiet { border-color: rgba(255,255,255,0.22); background: rgba(255,255,255,0.05); }
-        .ws-rewrite-shell { display: grid; gap: 8px; border-top: 1px solid rgba(255,255,255,0.12); padding-top: 10px; }
+        .ws-reveal-btn:disabled { opacity: 0.45; cursor: default; }
+        .ws-rewrite-shell { display: grid; gap: 10px; border-top: 1px solid rgba(255,255,255,0.12); padding-top: 12px; }
+        .ws-subsection { border-top: 1px solid rgba(255,255,255,0.08); padding-top: 10px; display: grid; gap: 8px; }
         .ws-fade-out { position: relative; max-height: 96px; overflow: hidden; }
         .ws-fade-out::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; height: 42px; background: linear-gradient(180deg, rgba(5,5,5,0), rgba(5,5,5,0.94)); pointer-events: none; }
 
@@ -382,17 +385,11 @@ export default function WorkspacePage() {
               <section className="ws-card ws-rail-card">
                 <div className="ws-panel-head">
                   <div className="ws-kicker">Story beats</div>
-                  <button
-                    className="ws-reveal-btn quiet"
-                    type="button"
-                    onClick={() => setShowAllBeats((current) => !current)}
-                  >
-                    {showAllBeats ? "Condense" : "Expand"}
-                  </button>
+                  <div className="ws-tag">{visibleBeatCount}/{storyCanvas.scene.beats.length} visible</div>
                 </div>
                 <p className="ws-section-intro">Ordered movement through pressure, signal, and practical next shape.</p>
                 <ol className="ws-list ws-story-list">
-                  {(showAllBeats ? storyCanvas.scene.beats : storyCanvas.scene.beats.slice(0, 2)).map((beat) => (
+                  {storyCanvas.scene.beats.slice(0, visibleBeatCount).map((beat) => (
                     <li key={beat.id}>
                       <div className="ws-story-item">
                         <div>
@@ -404,11 +401,23 @@ export default function WorkspacePage() {
                     </li>
                   ))}
                 </ol>
-                {!showAllBeats && storyCanvas.scene.beats.length > 2 ? (
+                {storyCanvas.scene.beats.length > 2 ? (
                   <div className="ws-reveal-row">
-                    <div className="ws-tag">{storyCanvas.scene.beats.length - 2} more beats available</div>
-                    <button className="ws-reveal-btn" type="button" onClick={() => setShowAllBeats(true)}>
-                      Show next beats
+                    <div className="ws-tag">{Math.max(storyCanvas.scene.beats.length - visibleBeatCount, 0)} more beats available</div>
+                    <button
+                      className="ws-reveal-btn quiet"
+                      type="button"
+                      disabled={visibleBeatCount >= storyCanvas.scene.beats.length}
+                      onClick={() => setVisibleBeatCount((current) => Math.min(current + 1, storyCanvas.scene.beats.length))}
+                    >
+                      Show next beat
+                    </button>
+                    <button
+                      className="ws-reveal-btn"
+                      type="button"
+                      onClick={() => setVisibleBeatCount((current) => (current >= storyCanvas.scene.beats.length ? 2 : storyCanvas.scene.beats.length))}
+                    >
+                      {visibleBeatCount >= storyCanvas.scene.beats.length ? "Condense" : "Show all beats"}
                     </button>
                   </div>
                 ) : null}
@@ -417,19 +426,13 @@ export default function WorkspacePage() {
               <section className="ws-card ws-rail-card">
                 <div className="ws-panel-head">
                   <div className="ws-kicker">Annotations</div>
-                  <button
-                    className="ws-reveal-btn quiet"
-                    type="button"
-                    onClick={() => setShowAllAnnotations((current) => !current)}
-                  >
-                    {showAllAnnotations ? "Condense" : "Expand"}
-                  </button>
+                  <div className="ws-tag">{visibleAnnotationCount}/{storyCanvas.annotations.length} visible</div>
                 </div>
-                <p className={`ws-section-intro ${showAllAnnotations ? "" : "ws-fade-out"}`}>
+                <p className={`ws-section-intro ${visibleAnnotationCount >= storyCanvas.annotations.length ? "" : "ws-fade-out"}`}>
                   Focus notes mark leverage points where wording or pacing can reduce friction.
                 </p>
                 <ul className="ws-list" style={{ paddingLeft: 16 }}>
-                  {(showAllAnnotations ? storyCanvas.annotations : storyCanvas.annotations.slice(0, 3)).map((annotation) => (
+                  {storyCanvas.annotations.slice(0, visibleAnnotationCount).map((annotation) => (
                     <li key={annotation.id}>
                       <span className="ws-tag" style={{ marginRight: 8 }}>
                         {annotation.category}
@@ -438,11 +441,27 @@ export default function WorkspacePage() {
                     </li>
                   ))}
                 </ul>
-                {!showAllAnnotations && storyCanvas.annotations.length > 3 ? (
+                {storyCanvas.annotations.length > 3 ? (
                   <div className="ws-reveal-row">
-                    <div className="ws-tag">{storyCanvas.annotations.length - 3} more annotations</div>
-                    <button className="ws-reveal-btn" type="button" onClick={() => setShowAllAnnotations(true)}>
-                      Reveal full set
+                    <div className="ws-tag">{Math.max(storyCanvas.annotations.length - visibleAnnotationCount, 0)} more annotations</div>
+                    <button
+                      className="ws-reveal-btn quiet"
+                      type="button"
+                      disabled={visibleAnnotationCount >= storyCanvas.annotations.length}
+                      onClick={() =>
+                        setVisibleAnnotationCount((current) => Math.min(current + 2, storyCanvas.annotations.length))
+                      }
+                    >
+                      Reveal next
+                    </button>
+                    <button
+                      className="ws-reveal-btn"
+                      type="button"
+                      onClick={() =>
+                        setVisibleAnnotationCount((current) => (current >= storyCanvas.annotations.length ? 3 : storyCanvas.annotations.length))
+                      }
+                    >
+                      {visibleAnnotationCount >= storyCanvas.annotations.length ? "Condense" : "Reveal full set"}
                     </button>
                   </div>
                 ) : null}
@@ -452,30 +471,50 @@ export default function WorkspacePage() {
                 <section className="ws-card ws-rail-card">
                   <div className="ws-panel-head">
                     <div className="ws-kicker">Constructive rewrite</div>
-                    <button
-                      className="ws-reveal-btn quiet"
-                      type="button"
-                      onClick={() => setShowRewriteDetails((current) => !current)}
-                    >
-                      {showRewriteDetails ? "Hide detail" : "Open detail"}
-                    </button>
+                    <div className="ws-tag">Staged view</div>
                   </div>
                   <div style={{ fontWeight: 600 }}>{storyCanvas.rewritePath.title}</div>
-                  {showRewriteDetails ? (
-                    <div className="ws-rewrite-shell">
-                      <div className="ws-muted" style={{ lineHeight: 1.72 }}>
-                        <strong style={{ color: "#f6f3ee" }}>Before:</strong> {storyCanvas.rewritePath.before}
-                      </div>
-                      <div className="ws-muted" style={{ lineHeight: 1.72 }}>
-                        <strong style={{ color: "#f6f3ee" }}>After:</strong> {storyCanvas.rewritePath.after}
-                      </div>
-                      <div className="ws-tag">{storyCanvas.rewritePath.rationale}</div>
-                    </div>
-                  ) : (
+                  <div className="ws-rewrite-shell">
                     <div className="ws-muted ws-fade-out" style={{ lineHeight: 1.68 }}>
                       {storyCanvas.rewritePath.after}
                     </div>
-                  )}
+                    <div className="ws-reveal-row">
+                      <button
+                        className="ws-reveal-btn quiet"
+                        type="button"
+                        onClick={() => setShowRewriteBeforeAfter((current) => !current)}
+                      >
+                        {showRewriteBeforeAfter ? "Hide before/after" : "Open before/after"}
+                      </button>
+                      <button
+                        className="ws-reveal-btn"
+                        type="button"
+                        onClick={() => setShowRewriteRationale((current) => !current)}
+                      >
+                        {showRewriteRationale ? "Hide rationale" : "Open rationale"}
+                      </button>
+                    </div>
+                    {showRewriteBeforeAfter ? (
+                      <div className="ws-subsection">
+                        <div className="ws-muted" style={{ lineHeight: 1.72 }}>
+                          <strong style={{ color: "#f6f3ee" }}>Before:</strong> {storyCanvas.rewritePath.before}
+                        </div>
+                        <div className="ws-muted" style={{ lineHeight: 1.72 }}>
+                          <strong style={{ color: "#f6f3ee" }}>After:</strong> {storyCanvas.rewritePath.after}
+                        </div>
+                      </div>
+                    ) : null}
+                    {showRewriteRationale ? (
+                      <div className="ws-subsection">
+                        <div className="ws-tag">{storyCanvas.rewritePath.rationale}</div>
+                      </div>
+                    ) : null}
+                    {!showRewriteBeforeAfter && !showRewriteRationale ? (
+                      <div className="ws-muted" style={{ lineHeight: 1.72 }}>
+                        Open details progressively for tone-level editing context.
+                      </div>
+                    ) : null}
+                  </div>
                 </section>
               ) : null}
 


### PR DESCRIPTION
### Motivation
- Improve Story Canvas readability and premium feel for long outputs in the workspace rail by reducing visual density and adding intentional staged reveals while preserving existing generation logic and route behavior.

### Description
- Changed the Story Canvas rail interaction from binary expand/condense to progressive staged reveal controls for beats using `visibleBeatCount` and incremental `Show next beat` plus full `Show all beats`/`Condense` behavior in `apps/web/src/app/workspace/page.tsx`.
- Reworked annotations into a staged reveal using `visibleAnnotationCount` with `Reveal next` and `Reveal full set`/`Condense` controls to improve scanability without changing annotation generation.
- Converted the rewrite path presentation into a calm always-visible preview with independently toggled `Before/After` and `Rationale` subsections using `showRewriteBeforeAfter` and `showRewriteRationale` so details are revealed progressively.
- Adjusted local CSS in the same file to increase spacing, add section dividers and softer subsection padding, and add disabled styling for reveal controls, while preserving the dark mono visual language and leaving `buildScene`, `buildAnnotations`, and `buildRewrite` usage unchanged.

### Testing
- Ran `pnpm --dir apps/web typecheck` and the typecheck passed successfully.
- Ran `pnpm --dir apps/web build` and the production build completed successfully (pages generated and compilation succeeded).
- Confirmed working tree shows only the intended UI file modified (`apps/web/src/app/workspace/page.tsx`) before commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d35b60ae8c8332a23af0e5226d2c8d)