### PR TITLE
Public rewrite v1: marketing copy source + studio/about refactor

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -1,48 +1,24 @@
 import Link from "next/link";
 import { AppShell } from "../../components/app-shell";
-
-const sections = [
-  {
-    title: "What Defrag does",
-    body: "Defrag turns a difficult interaction into structured relational analysis. It helps you understand what may be happening, how each side may be reading the moment, where pressure changed, and what move makes sense next.",
-  },
-  {
-    title: "How the system reads a moment",
-    body: "You bring the exchange, the people involved, and the context that matters. Defrag evaluates the interaction, compares perspective, reads pressure and timing, and returns a clearer view of the dynamic instead of only reflecting one narrator's story.",
-  },
-  {
-    title: "What the workspace returns",
-    body: "The workspace is designed to return structured outputs such as what may be happening, what may be getting misread, where the pressure changed, what pattern is forming, and what wording or next step is most likely to help.",
-  },
-  {
-    title: "Who it is built for",
-    body: "Defrag can be used for one person's recurring patterns, two-person interactions, family systems, team systems, and broader relational structures where tension and communication move across more than one participant.",
-  },
-  {
-    title: "What it is not",
-    body: "Defrag is not diagnosis, not generic advice, and not a replacement for professional support. It is a relational intelligence system built to make difficult interactions more readable and better decisions more possible.",
-  },
-];
+import { marketingCopy } from "../../content/marketingCopy";
 
 export default function AboutPage() {
   return (
     <AppShell
-      eyebrow="How it works"
-      title="How Defrag reads a difficult interaction."
-      description="Defrag operates as a relational reasoning system. It helps people understand what may be happening, where pressure changed, and what move is most likely to help next."
+      eyebrow={marketingCopy.about.eyebrow}
+      title={marketingCopy.about.title}
+      description={marketingCopy.about.description}
       accent="#c8d8a2"
     >
       <div style={{ maxWidth: 1120, margin: "0 auto", padding: "0 16px" }}>
         <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 320px", gap: 56 }} className="about-grid">
           <div style={{ display: "grid", gap: 48 }}>
-            {sections.map((section) => (
+            {marketingCopy.about.sections.map((section) => (
               <div key={section.title} style={{ display: "grid", gap: 14 }}>
                 <h2 style={{ margin: 0, fontSize: "clamp(1.6rem, 3vw, 2.15rem)", fontWeight: 500, letterSpacing: "-0.03em", color: "white" }}>
                   {section.title}
                 </h2>
-                <p style={{ margin: 0, color: "rgba(245, 245, 245, 0.68)", lineHeight: 1.82, fontSize: 18, fontWeight: 300 }}>
-                  {section.body}
-                </p>
+                <p style={{ margin: 0, color: "rgba(245, 245, 245, 0.68)", lineHeight: 1.82, fontSize: 18, fontWeight: 300 }}>{section.body}</p>
               </div>
             ))}
           </div>
@@ -53,11 +29,11 @@ export default function AboutPage() {
                 Open Defrag
               </div>
               <div style={{ display: "grid", gap: 12 }}>
-                <Link href="/login" style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "16px", borderRadius: 14, background: "white", color: "#050505", textDecoration: "none", fontWeight: 600, fontSize: 16 }}>
-                  Sign in
+                <Link href="/enter" style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "16px", borderRadius: 14, background: "white", color: "#050505", textDecoration: "none", fontWeight: 600, fontSize: 16 }}>
+                  Open Defrag
                 </Link>
-                <Link href="/dynamics" style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "16px", borderRadius: 14, border: "1px solid rgba(255,255,255,0.1)", background: "rgba(255,255,255,0.03)", color: "white", textDecoration: "none", fontSize: 16 }}>
-                  View workspace
+                <Link href="/studio#how-it-works" style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "16px", borderRadius: 14, border: "1px solid rgba(255,255,255,0.1)", background: "rgba(255,255,255,0.03)", color: "white", textDecoration: "none", fontSize: 16 }}>
+                  See how it works
                 </Link>
               </div>
             </div>
@@ -67,13 +43,7 @@ export default function AboutPage() {
                 Core capabilities
               </div>
               <div style={{ display: "grid", gap: 12 }}>
-                {[
-                  "personal pattern analysis",
-                  "1:1 interaction analysis",
-                  "multi-person system analysis",
-                  "perspective comparison",
-                  "structured next-step guidance",
-                ].map((item) => (
+                {marketingCopy.coreValue.capabilities.map((item) => (
                   <div key={item} style={{ fontSize: 14, color: "rgba(245,245,245,0.62)", lineHeight: 1.6 }}>
                     {item}
                   </div>

--- a/apps/web/src/app/studio/page.tsx
+++ b/apps/web/src/app/studio/page.tsx
@@ -1,510 +1,184 @@
 import Link from "next/link";
-
-const FLOW = [
-  {
-    label: "Baseline",
-    body: "Start with a short natal baseline so Defrag understands how pressure may land for you.",
-  },
-  {
-    label: "Field read",
-    body: "Open one live relationship moment and map what may be happening between people.",
-  },
-  {
-    label: "Next move",
-    body: "Leave with one clear step that protects dignity and lowers distortion.",
-  },
-];
+import { ClosingCtaSection } from "../../components/marketing/ClosingCtaSection";
+import { CoreValueSection } from "../../components/marketing/CoreValueSection";
+import { FaqSection } from "../../components/marketing/FaqSection";
+import { HeroSection } from "../../components/marketing/HeroSection";
+import { HowItWorksSection } from "../../components/marketing/HowItWorksSection";
+import { OutputVisibilitySection } from "../../components/marketing/OutputVisibilitySection";
+import { ProductSystemSection } from "../../components/marketing/ProductSystemSection";
+import { UseCasesSection } from "../../components/marketing/UseCasesSection";
+import { marketingCopy } from "../../content/marketingCopy";
 
 export default function StudioHomePage() {
   return (
-    <main style={{ minHeight: "100vh", background: "#050505", color: "#f5f2ec" }}>
+    <main className="mk-page">
       <style>{`
-        .st-page {
-          position: relative;
-          isolation: isolate;
-          overflow: hidden;
+        .mk-page {
           min-height: 100vh;
           background:
             radial-gradient(1200px 680px at 78% -8%, rgba(235, 219, 190, 0.12), transparent 64%),
             radial-gradient(920px 620px at 18% 20%, rgba(255, 255, 255, 0.05), transparent 68%),
             linear-gradient(160deg, #080808 0%, #050505 42%, #090909 100%);
+          color: #f5f2ec;
         }
-
-        .st-page::before {
-          content: "";
-          position: absolute;
-          inset: 0;
-          pointer-events: none;
-          opacity: 0.26;
-          background-image:
-            radial-gradient(circle at 18% 24%, rgba(255, 255, 255, 0.16) 0.7px, transparent 0.8px),
-            radial-gradient(circle at 74% 80%, rgba(255, 255, 255, 0.13) 0.7px, transparent 0.8px);
-          background-size: 3px 3px, 4px 4px;
-          mix-blend-mode: soft-light;
-          z-index: 0;
-        }
-
-        .st-shell {
-          position: relative;
-          z-index: 1;
-          width: min(1560px, 100%);
+        .mk-shell {
+          width: min(1120px, 100%);
           margin: 0 auto;
-          padding: 36px clamp(18px, 3.4vw, 48px) 120px;
+          padding: 30px clamp(16px, 3.4vw, 40px) 96px;
           display: grid;
-          gap: clamp(54px, 9vw, 118px);
+          gap: 56px;
         }
-
-        .st-topbar {
+        .mk-header {
           display: flex;
           justify-content: space-between;
-          align-items: flex-start;
-          gap: 18px;
+          align-items: center;
+          flex-wrap: wrap;
+          gap: 14px;
         }
-
-        .st-brand { display: grid; gap: 4px; }
-        .st-kicker {
-          font-size: 10px;
-          letter-spacing: 0.21em;
-          text-transform: uppercase;
-          color: rgba(245, 242, 236, 0.5);
-        }
-        .st-muted { color: rgba(245, 242, 236, 0.68); }
-
-        .st-nav { display: flex; gap: 10px; flex-wrap: wrap; }
-        .st-link {
-          color: #f5f2ec;
-          text-decoration: none;
+        .mk-brand {
           font-size: 11px;
-          letter-spacing: 0.1em;
+          letter-spacing: 0.2em;
           text-transform: uppercase;
-          padding: 9px 0;
-          border-bottom: 1px solid rgba(245, 242, 236, 0.22);
-          opacity: 0.8;
-          transition: opacity 160ms ease, border-color 160ms ease;
+          color: rgba(245, 242, 236, 0.56);
         }
-        .st-link:hover { opacity: 1; border-color: rgba(245, 242, 236, 0.5); }
-
-        .st-hero {
-          display: grid;
-          grid-template-columns: minmax(0, 1.06fr) minmax(0, 0.94fr);
-          gap: clamp(28px, 5vw, 80px);
-          align-items: start;
+        .mk-nav { display: flex; gap: 12px; flex-wrap: wrap; }
+        .mk-nav a {
+          color: rgba(245, 242, 236, 0.84);
+          text-decoration: none;
+          font-size: 12px;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          border-bottom: 1px solid rgba(245, 242, 236, 0.24);
+          padding: 6px 0;
         }
-
-        .st-intro {
-          display: grid;
-          gap: clamp(32px, 4.4vw, 52px);
-          padding-top: clamp(28px, 7vw, 120px);
-          max-width: 760px;
+        .mk-section { display: grid; gap: 14px; }
+        .mk-hero { padding-top: 10px; }
+        .mk-kicker {
+          font-size: 10px;
+          letter-spacing: 0.2em;
+          text-transform: uppercase;
+          color: rgba(245, 242, 236, 0.52);
         }
-
-        .st-title {
+        .mk-title {
           margin: 0;
           font-family: var(--font-display), serif;
-          font-size: clamp(3rem, 8.6vw, 7.8rem);
-          line-height: 0.84;
-          letter-spacing: -0.048em;
-          text-wrap: balance;
+          font-size: clamp(2.7rem, 8vw, 6.4rem);
+          line-height: 0.9;
+          letter-spacing: -0.045em;
           max-width: 13ch;
         }
-
-        .st-lead {
+        .mk-h2 {
           margin: 0;
-          font-size: clamp(1rem, 1.6vw, 1.16rem);
-          line-height: 1.88;
-          max-width: 54ch;
+          font-family: var(--font-display), serif;
+          font-size: clamp(1.7rem, 4.2vw, 3rem);
+          line-height: 0.95;
+          letter-spacing: -0.03em;
         }
-
-        .st-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
-        .st-btn {
-          text-decoration: none;
+        .mk-h3 {
+          margin: 0;
+          font-size: 1.1rem;
+          letter-spacing: -0.01em;
+          color: #fff;
+        }
+        .mk-lead,
+        .mk-body {
+          margin: 0;
+          color: rgba(245, 242, 236, 0.72);
+          line-height: 1.8;
+          font-size: clamp(0.98rem, 1.35vw, 1.08rem);
+          max-width: 70ch;
+        }
+        .mk-actions { display: flex; gap: 12px; flex-wrap: wrap; padding-top: 4px; }
+        .mk-btn {
           display: inline-flex;
           align-items: center;
           justify-content: center;
+          text-decoration: none;
           border-radius: 999px;
-          transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+          padding: 13px 22px;
+          font-size: 12px;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
         }
-        .st-btn:hover { transform: translateY(-1px); }
-
-        .st-btn-primary {
+        .mk-btn-primary {
           background: linear-gradient(135deg, #faf6ee 0%, #e7d7b8 92%);
           color: #090909;
           font-weight: 600;
-          font-size: 13px;
-          letter-spacing: 0.06em;
-          text-transform: uppercase;
-          padding: 15px 24px;
-          box-shadow: 0 0 0 1px rgba(243, 231, 209, 0.2), 0 12px 32px rgba(10, 10, 10, 0.4);
         }
-        .st-btn-secondary {
+        .mk-btn-secondary {
           color: #f5f2ec;
           border: 1px solid rgba(255, 255, 255, 0.26);
           background: rgba(255, 255, 255, 0.03);
-          font-size: 12px;
-          letter-spacing: 0.09em;
-          text-transform: uppercase;
-          padding: 14px 20px;
         }
-        .st-btn-tertiary {
-          color: rgba(245, 242, 236, 0.78);
-          font-size: 12px;
-          letter-spacing: 0.1em;
-          text-transform: uppercase;
-          padding: 10px 4px;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-        }
-
-        .st-quiet-note {
+        .mk-note {
           font-size: 11px;
           letter-spacing: 0.12em;
           text-transform: uppercase;
           color: rgba(245, 242, 236, 0.44);
         }
-
-        .st-field {
-          position: relative;
-          min-height: 760px;
-          padding-top: clamp(8px, 3vw, 40px);
-        }
-
-        .st-field::before {
-          content: "";
-          position: absolute;
-          right: -6%;
-          top: 15%;
-          width: 92%;
-          height: 74%;
-          border-radius: 46% 54% 50% 50%;
-          background:
-            radial-gradient(circle at 20% 24%, rgba(255, 255, 255, 0.1), transparent 44%),
-            radial-gradient(circle at 76% 66%, rgba(233, 214, 183, 0.16), transparent 48%),
-            linear-gradient(168deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.02));
-          filter: blur(0.2px);
-          opacity: 0.85;
-        }
-
-        .st-thread {
-          position: absolute;
-          left: 0;
-          top: 0;
-          width: min(420px, 88%);
+        .mk-list {
+          margin: 0;
+          padding-left: 20px;
           display: grid;
-          gap: 14px;
-          z-index: 4;
+          gap: 10px;
+          color: rgba(245, 242, 236, 0.72);
+          line-height: 1.75;
         }
-
-        .st-bubble {
-          padding: 16px 18px;
-          backdrop-filter: blur(14px);
-          border: 1px solid rgba(255, 255, 255, 0.14);
-          background: rgba(255, 255, 255, 0.038);
-          line-height: 1.72;
-          font-size: 14px;
+        .mk-list-tight { gap: 6px; }
+        .mk-grid-2 {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) minmax(280px, 0.86fr);
+          gap: 24px;
+          align-items: start;
         }
-
-        .st-bubble.assistant {
-          margin-left: 42px;
-          background: linear-gradient(140deg, rgba(226, 207, 175, 0.21), rgba(255, 255, 255, 0.04));
-        }
-
-        .st-preview {
-          position: absolute;
-          inset: 118px 0 0 54px;
-          border-radius: 28px;
-          overflow: hidden;
+        .mk-card {
+          background: rgba(255, 255, 255, 0.03);
           border: 1px solid rgba(255, 255, 255, 0.1);
-          background:
-            radial-gradient(circle at 18% 28%, rgba(255, 255, 255, 0.08), transparent 34%),
-            radial-gradient(circle at 74% 42%, rgba(222, 201, 169, 0.14), transparent 40%),
-            linear-gradient(160deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015));
+          border-radius: 20px;
+          padding: 22px;
         }
-
-        .st-scan {
-          position: absolute;
-          inset: 0;
-          opacity: 0.2;
-          background-image: linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-          background-size: 100% 36px;
-          animation: stScan 8s linear infinite;
-        }
-
-        .st-orbit {
-          position: absolute;
-          left: 55%;
-          top: 45%;
-          width: min(440px, 84%);
-          aspect-ratio: 1;
-          transform: translate(-50%, -50%);
-          border-radius: 50%;
-          border: 1px solid rgba(255, 255, 255, 0.15);
-        }
-
-        .st-orbit::before,
-        .st-orbit::after {
-          content: "";
-          position: absolute;
-          inset: 12%;
-          border-radius: 50%;
-          border: 1px solid rgba(255, 255, 255, 0.08);
-        }
-
-        .st-orbit::after { inset: 28%; }
-
-        .st-line {
-          position: absolute;
-          left: 56%;
-          top: 47%;
-          width: 340px;
-          height: 1px;
-          transform: translate(-50%, -50%);
-          background: linear-gradient(90deg, rgba(228, 210, 179, 0), rgba(228, 210, 179, 0.4), rgba(255, 255, 255, 0.68), rgba(228, 210, 179, 0.4), rgba(228, 210, 179, 0));
-        }
-
-        .st-line::after {
-          content: "";
-          position: absolute;
-          left: -28%;
-          top: -1px;
-          width: 24%;
-          height: 3px;
-          background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.78), transparent);
-          animation: stSweep 3.6s linear infinite;
-        }
-
-        .st-node {
-          position: absolute;
-          width: 170px;
-          aspect-ratio: 1;
-          border-radius: 50%;
-          border: 1px solid rgba(255, 255, 255, 0.18);
-          background: radial-gradient(circle at 50% 40%, rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.03));
-          display: grid;
-          place-items: center;
-          text-align: center;
-          z-index: 3;
-          box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
-        }
-
-        .st-node.you { left: 37%; top: 41%; transform: translate(-50%, -50%); }
-        .st-node.other { left: 73%; top: 47%; transform: translate(-50%, -50%); }
-
-        .st-summary {
-          position: absolute;
-          left: 24px;
-          right: 24px;
-          bottom: 22px;
-          padding: 18px 20px;
-          background: linear-gradient(180deg, rgba(6, 6, 6, 0.48), rgba(10, 10, 10, 0.72));
-          border-top: 1px solid rgba(255, 255, 255, 0.12);
-          z-index: 5;
-          display: grid;
-          gap: 9px;
-        }
-
-        .st-summary-title {
-          margin: 0;
-          font-family: var(--font-display), serif;
-          font-size: clamp(1.5rem, 3.1vw, 2rem);
-          line-height: 1;
-          letter-spacing: -0.02em;
-        }
-
-        .st-flow-wrap {
-          display: grid;
-          grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-          gap: clamp(22px, 5vw, 58px);
-          align-items: end;
-        }
-
-        .st-manifesto {
-          max-width: 520px;
-          display: grid;
-          gap: 18px;
-          padding-right: 20px;
-        }
-
-        .st-manifesto h2 {
-          margin: 0;
-          font-family: var(--font-display), serif;
-          font-size: clamp(2.1rem, 4.4vw, 4rem);
-          line-height: 0.9;
-          letter-spacing: -0.036em;
-          max-width: 12ch;
-        }
-
-        .st-flow {
-          display: grid;
-          gap: 0;
-          border-left: 1px solid rgba(255, 255, 255, 0.18);
-          padding-left: clamp(18px, 2vw, 28px);
-        }
-
-        .st-flow-item {
+        .mk-steps { display: grid; gap: 12px; }
+        .mk-step {
+          border-left: 1px solid rgba(255, 255, 255, 0.22);
+          padding-left: 16px;
           display: grid;
           gap: 8px;
-          padding: 18px 0 20px;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.12);
         }
-
-        .st-flow-item:last-child { border-bottom: 0; padding-bottom: 0; }
-
-        .st-flow-label {
+        .mk-step-label {
           font-size: 10px;
           letter-spacing: 0.2em;
           text-transform: uppercase;
-          color: rgba(245, 242, 236, 0.46);
+          color: rgba(245, 242, 236, 0.58);
         }
-
-        @keyframes stSweep { from { left: -28%; } to { left: 106%; } }
-        @keyframes stScan {
-          from { transform: translateY(-6px); }
-          50% { transform: translateY(6px); }
-          to { transform: translateY(-6px); }
+        .mk-faq-grid {
+          display: grid;
+          gap: 12px;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
         }
-
-        @media (max-width: 1180px) {
-          .st-hero,
-          .st-flow-wrap {
-            grid-template-columns: 1fr;
-          }
-
-          .st-intro { padding-top: 10px; max-width: 100%; }
-          .st-field { min-height: 800px; }
-          .st-preview { inset: 178px 0 0 0; }
-        }
-
-        @media (max-width: 760px) {
-          .st-shell { padding: 24px 16px 90px; gap: 68px; }
-          .st-topbar { flex-direction: column; }
-          .st-title { font-size: clamp(2.4rem, 13.5vw, 4rem); }
-          .st-thread { position: relative; width: 100%; }
-          .st-bubble.assistant { margin-left: 24px; }
-          .st-field { min-height: 760px; }
-          .st-preview { inset: 168px 0 0 0; border-radius: 22px; }
-          .st-line { width: 220px; }
-          .st-node { width: 126px; }
-          .st-node.you { left: 35%; top: 44%; }
-          .st-node.other { left: 71%; top: 50%; }
-          .st-summary-title { font-size: 1.35rem; }
+        @media (max-width: 960px) {
+          .mk-grid-2,
+          .mk-faq-grid { grid-template-columns: 1fr; }
+          .mk-shell { gap: 44px; }
         }
       `}</style>
+      <div className="mk-shell">
+        <header className="mk-header">
+          <div className="mk-brand">Defrag · Studio</div>
+          <nav className="mk-nav">
+            <Link href="/signin">Sign in</Link>
+            <Link href="/about">About</Link>
+            <Link href="/pricing">Pricing</Link>
+          </nav>
+        </header>
 
-      <div className="st-page">
-        <div className="st-shell">
-          <header className="st-topbar">
-            <div className="st-brand">
-              <div className="st-kicker">Defrag</div>
-              <div>Studio</div>
-            </div>
-
-            <nav className="st-nav">
-              <Link className="st-link" href="/signin">Sign in</Link>
-              <Link className="st-link" href="/signup">Create account</Link>
-              <Link className="st-link" href="/workspace">Workspace preview</Link>
-            </nav>
-          </header>
-
-          <section className="st-hero">
-            <div className="st-intro">
-              <div style={{ display: "grid", gap: 22 }}>
-                <div className="st-kicker">Relationship intelligence, rendered clearly</div>
-                <h1 className="st-title">See what is happening between people.</h1>
-                <p className="st-lead st-muted">
-                  Defrag turns difficult relationship moments into calm, plain-language field reads so you can decide what to do next with steadiness.
-                </p>
-              </div>
-
-              <div style={{ display: "grid", gap: 15 }}>
-                <div className="st-actions">
-                  <Link className="st-btn st-btn-primary" href="/enter">Open Defrag</Link>
-                  <Link className="st-btn st-btn-secondary" href="/start">Start baseline</Link>
-                  <Link className="st-btn st-btn-tertiary" href="/billing">View plans</Link>
-                </div>
-
-                <div className="st-quiet-note">Built for emotional safety • plain-language first • desktop + mobile</div>
-              </div>
-            </div>
-
-            <div className="st-field">
-              <div className="st-thread">
-                <div className="st-bubble user">
-                  <div className="st-kicker" style={{ marginBottom: 8 }}>You</div>
-                  I want to talk to my mom tonight, but I think we may miss each other again.
-                </div>
-                <div className="st-bubble assistant">
-                  <div className="st-kicker" style={{ marginBottom: 8 }}>Defrag</div>
-                  This may be a moment where both people care, but pressure is distorting how each side hears the other.
-                </div>
-              </div>
-
-              <div className="st-preview">
-                <div className="st-scan" />
-                <div className="st-orbit" />
-                <div className="st-line" />
-
-                <div className="st-node you">
-                  <div className="st-kicker" style={{ fontSize: 10 }}>self</div>
-                  <div style={{ fontSize: 28, fontFamily: "var(--font-display), serif" }}>You</div>
-                  <div className="st-muted" style={{ fontSize: 12 }}>trying to be heard</div>
-                </div>
-
-                <div className="st-node other">
-                  <div className="st-kicker" style={{ fontSize: 10 }}>family</div>
-                  <div style={{ fontSize: 28, fontFamily: "var(--font-display), serif" }}>Mother</div>
-                  <div className="st-muted" style={{ fontSize: 12 }}>guarded</div>
-                </div>
-
-                <div className="st-summary">
-                  <div className="st-kicker">Live field preview</div>
-                  <h2 className="st-summary-title">What may be happening</h2>
-                  <div className="st-muted" style={{ lineHeight: 1.72 }}>
-                    Both people may be trying to protect the relationship, but the pace of the exchange is making each side harder to hear.
-                  </div>
-                </div>
-              </div>
-            </article>
-            <article className="studio-panel">
-              <div className="studio-kicker">What stays consistent</div>
-              <ul className="studio-list">
-                <li>Simple language you can use in real conversations.</li>
-                <li>Guidance that protects dignity for both people.</li>
-                <li>A consistent environment across intake, workspace, and account surfaces.</li>
-              </ul>
-            </article>
-          </section>
-
-          <section className="studio-close">
-            <div className="studio-kicker">Start when you are ready</div>
-            <div style={{ fontSize: 48, lineHeight: 0.92, fontFamily: "var(--font-display), serif" }}>Enter the studio and open one relationship moment clearly.</div>
-            <div className="studio-cta">
-              <Link className="studio-btn primary" href="/enter">
-                Open Defrag
-              </Link>
-              <Link className="studio-btn secondary" href="/signin/studio">
-                Sign in to continue
-              </Link>
-            </div>
-          </section>
-
-          <section className="st-flow-wrap">
-            <article className="st-manifesto">
-              <div className="st-kicker">How the flow feels</div>
-              <h2>From baseline to live field, with one coherent rhythm.</h2>
-              <p className="st-muted" style={{ margin: 0, lineHeight: 1.84 }}>
-                The experience is designed to reduce noise. You begin with baseline context, then move into one interaction, compare perspectives, and leave with one grounded next move.
-              </p>
-            </article>
-
-            <aside className="st-flow">
-              {FLOW.map((item) => (
-                <div key={item.label} className="st-flow-item">
-                  <div className="st-flow-label">{item.label}</div>
-                  <div className="st-muted" style={{ lineHeight: 1.75 }}>{item.body}</div>
-                </div>
-              ))}
-            </aside>
-          </section>
-        </div>
+        <HeroSection copy={marketingCopy.hero} />
+        <OutputVisibilitySection copy={marketingCopy.outputVisibility} />
+        <CoreValueSection copy={marketingCopy.coreValue} />
+        <UseCasesSection copy={marketingCopy.useCases} />
+        <HowItWorksSection copy={marketingCopy.howItWorks} />
+        <ProductSystemSection copy={marketingCopy.productSystem} />
+        <FaqSection items={marketingCopy.faq} />
+        <ClosingCtaSection copy={marketingCopy.closingCta} />
       </div>
     </main>
   );

--- a/apps/web/src/components/marketing/ClosingCtaSection.tsx
+++ b/apps/web/src/components/marketing/ClosingCtaSection.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import type { ClosingCtaCopy } from "../../content/marketingCopy";
+
+interface ClosingCtaSectionProps {
+  copy: ClosingCtaCopy;
+}
+
+export function ClosingCtaSection({ copy }: ClosingCtaSectionProps) {
+  return (
+    <section className="mk-section mk-card">
+      <div className="mk-kicker">{copy.kicker}</div>
+      <h2 className="mk-h2">{copy.title}</h2>
+      <p className="mk-body">{copy.description}</p>
+      <div className="mk-actions">
+        <Link className="mk-btn mk-btn-primary" href={copy.primaryCtaHref}>
+          {copy.primaryCtaLabel}
+        </Link>
+        <Link className="mk-btn mk-btn-secondary" href={copy.secondaryCtaHref}>
+          {copy.secondaryCtaLabel}
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/CoreValueSection.tsx
+++ b/apps/web/src/components/marketing/CoreValueSection.tsx
@@ -1,0 +1,38 @@
+import type { CoreValueCopy } from "../../content/marketingCopy";
+
+interface CoreValueSectionProps {
+  copy: CoreValueCopy;
+}
+
+export function CoreValueSection({ copy }: CoreValueSectionProps) {
+  return (
+    <section className="mk-section mk-grid-2">
+      <article>
+        <div className="mk-kicker">{copy.kicker}</div>
+        <h2 className="mk-h2">{copy.title}</h2>
+        <p className="mk-body">{copy.description}</p>
+        <ul className="mk-list">
+          {copy.coreValueBullets.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </article>
+      <aside className="mk-card">
+        <h3 className="mk-h3">{copy.productOfferingTitle}</h3>
+        <ul className="mk-list">
+          {copy.productOfferingBullets.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <h3 className="mk-h3" style={{ marginTop: 24 }}>
+          {copy.capabilitiesTitle}
+        </h3>
+        <ul className="mk-list mk-list-tight">
+          {copy.capabilities.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </aside>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/FaqSection.tsx
+++ b/apps/web/src/components/marketing/FaqSection.tsx
@@ -1,0 +1,22 @@
+import type { FaqItem } from "../../content/marketingCopy";
+
+interface FaqSectionProps {
+  items: FaqItem[];
+}
+
+export function FaqSection({ items }: FaqSectionProps) {
+  return (
+    <section className="mk-section">
+      <div className="mk-kicker">FAQ</div>
+      <h2 className="mk-h2">Common questions</h2>
+      <div className="mk-faq-grid">
+        {items.map((item) => (
+          <article key={item.question} className="mk-card">
+            <h3 className="mk-h3">{item.question}</h3>
+            <p className="mk-body">{item.answer}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/HeroSection.tsx
+++ b/apps/web/src/components/marketing/HeroSection.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import type { HeroCopy } from "../../content/marketingCopy";
+
+interface HeroSectionProps {
+  copy: HeroCopy;
+}
+
+export function HeroSection({ copy }: HeroSectionProps) {
+  return (
+    <section className="mk-section mk-hero">
+      <div className="mk-kicker">{copy.kicker}</div>
+      <h1 className="mk-title">{copy.title}</h1>
+      <p className="mk-lead">{copy.description}</p>
+      <div className="mk-actions">
+        <Link className="mk-btn mk-btn-primary" href={copy.primaryCtaHref}>
+          {copy.primaryCtaLabel}
+        </Link>
+        <Link className="mk-btn mk-btn-secondary" href={copy.secondaryCtaHref}>
+          {copy.secondaryCtaLabel}
+        </Link>
+      </div>
+      <div className="mk-note">{copy.quietNote}</div>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/HowItWorksSection.tsx
+++ b/apps/web/src/components/marketing/HowItWorksSection.tsx
@@ -1,0 +1,23 @@
+import type { HowItWorksCopy } from "../../content/marketingCopy";
+
+interface HowItWorksSectionProps {
+  copy: HowItWorksCopy;
+}
+
+export function HowItWorksSection({ copy }: HowItWorksSectionProps) {
+  return (
+    <section id="how-it-works" className="mk-section">
+      <div className="mk-kicker">{copy.kicker}</div>
+      <h2 className="mk-h2">{copy.title}</h2>
+      <p className="mk-body">{copy.intro}</p>
+      <div className="mk-steps">
+        {copy.steps.map((step) => (
+          <article key={step.label} className="mk-step">
+            <div className="mk-step-label">{step.label}</div>
+            <p className="mk-body">{step.body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/OutputVisibilitySection.tsx
+++ b/apps/web/src/components/marketing/OutputVisibilitySection.tsx
@@ -1,0 +1,20 @@
+import type { OutputVisibilityCopy } from "../../content/marketingCopy";
+
+interface OutputVisibilitySectionProps {
+  copy: OutputVisibilityCopy;
+}
+
+export function OutputVisibilitySection({ copy }: OutputVisibilitySectionProps) {
+  return (
+    <section className="mk-section">
+      <div className="mk-kicker">{copy.kicker}</div>
+      <h2 className="mk-h2">{copy.title}</h2>
+      <p className="mk-body">{copy.description}</p>
+      <ul className="mk-list">
+        {copy.bullets.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/ProductSystemSection.tsx
+++ b/apps/web/src/components/marketing/ProductSystemSection.tsx
@@ -1,0 +1,20 @@
+import type { ProductSystemCopy } from "../../content/marketingCopy";
+
+interface ProductSystemSectionProps {
+  copy: ProductSystemCopy;
+}
+
+export function ProductSystemSection({ copy }: ProductSystemSectionProps) {
+  return (
+    <section className="mk-section">
+      <div className="mk-kicker">{copy.kicker}</div>
+      <h2 className="mk-h2">{copy.title}</h2>
+      <p className="mk-body">{copy.intro}</p>
+      <ul className="mk-list">
+        {copy.systemBullets.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/marketing/UseCasesSection.tsx
+++ b/apps/web/src/components/marketing/UseCasesSection.tsx
@@ -1,0 +1,20 @@
+import type { UseCasesCopy } from "../../content/marketingCopy";
+
+interface UseCasesSectionProps {
+  copy: UseCasesCopy;
+}
+
+export function UseCasesSection({ copy }: UseCasesSectionProps) {
+  return (
+    <section className="mk-section">
+      <div className="mk-kicker">{copy.kicker}</div>
+      <h2 className="mk-h2">{copy.title}</h2>
+      <p className="mk-body">{copy.intro}</p>
+      <ul className="mk-list">
+        {copy.cases.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/public-preview-cta.tsx
+++ b/apps/web/src/components/public-preview-cta.tsx
@@ -12,10 +12,10 @@ interface PublicPreviewCtaProps {
 export function PublicPreviewCta({
   title,
   description,
-  primaryLabel = "Sign in",
-  primaryHref = "/login",
-  secondaryLabel = "Back home",
-  secondaryHref = "/",
+  primaryLabel = "Open Defrag",
+  primaryHref = "/enter",
+  secondaryLabel = "See how it works",
+  secondaryHref = "/studio#how-it-works",
 }: PublicPreviewCtaProps) {
   return (
     <div style={{ display: "grid", gap: 20, maxWidth: 640 }}>

--- a/apps/web/src/content/marketingCopy.ts
+++ b/apps/web/src/content/marketingCopy.ts
@@ -1,0 +1,229 @@
+export interface HeroCopy {
+  kicker: string;
+  title: string;
+  description: string;
+  quietNote: string;
+  primaryCtaLabel: string;
+  primaryCtaHref: string;
+  secondaryCtaLabel: string;
+  secondaryCtaHref: string;
+}
+
+export interface OutputVisibilityCopy {
+  kicker: string;
+  title: string;
+  description: string;
+  bullets: string[];
+}
+
+export interface CoreValueCopy {
+  kicker: string;
+  title: string;
+  description: string;
+  coreValueBullets: string[];
+  productOfferingTitle: string;
+  productOfferingBullets: string[];
+  capabilitiesTitle: string;
+  capabilities: string[];
+}
+
+export interface UseCasesCopy {
+  kicker: string;
+  title: string;
+  intro: string;
+  cases: string[];
+}
+
+export interface HowItWorksCopy {
+  kicker: string;
+  title: string;
+  intro: string;
+  steps: Array<{ label: string; body: string }>;
+}
+
+export interface ProductSystemCopy {
+  kicker: string;
+  title: string;
+  intro: string;
+  systemBullets: string[];
+}
+
+export interface AboutCopy {
+  eyebrow: string;
+  title: string;
+  description: string;
+  sections: Array<{ title: string; body: string }>;
+}
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+export interface ClosingCtaCopy {
+  kicker: string;
+  title: string;
+  description: string;
+  primaryCtaLabel: string;
+  primaryCtaHref: string;
+  secondaryCtaLabel: string;
+  secondaryCtaHref: string;
+}
+
+export interface MarketingCopy {
+  hero: HeroCopy;
+  outputVisibility: OutputVisibilityCopy;
+  coreValue: CoreValueCopy;
+  useCases: UseCasesCopy;
+  howItWorks: HowItWorksCopy;
+  productSystem: ProductSystemCopy;
+  about: AboutCopy;
+  faq: FaqItem[];
+  closingCta: ClosingCtaCopy;
+}
+
+export const marketingCopy: MarketingCopy = {
+  hero: {
+    kicker: "Defrag Studio",
+    title: "See what is happening between people.",
+    description:
+      "Defrag turns difficult relationship moments into calm, plain-language field reads so you can decide what to do next with steadiness.",
+    quietNote: "Built for emotional safety • plain-language first • desktop + mobile",
+    primaryCtaLabel: "Open Defrag",
+    primaryCtaHref: "/enter",
+    secondaryCtaLabel: "See how it works",
+    secondaryCtaHref: "/studio#how-it-works",
+  },
+  outputVisibility: {
+    kicker: "Output visibility",
+    title: "Readable outputs you can actually use.",
+    description:
+      "Defrag returns structured outputs that make live dynamics easier to understand before you act.",
+    bullets: [
+      "What may be happening between each person in the moment.",
+      "Where pressure changed and what may be getting misread.",
+      "One grounded next move in language you can use immediately.",
+    ],
+  },
+  coreValue: {
+    kicker: "Core value",
+    title: "Relational intelligence without shame language.",
+    description:
+      "Defrag helps people get clearer without reducing anyone to a label. The system is anti-stigma, plain-language, and designed to protect dignity.",
+    coreValueBullets: [
+      "Calm framing over escalation.",
+      "Perspective comparison instead of one-sided certainty.",
+      "Actionable next steps over generic advice.",
+    ],
+    productOfferingTitle: "Product offering",
+    productOfferingBullets: [
+      "Studio flow for baseline, live field reading, and next step planning.",
+      "Structured workspace outputs built for one conversation at a time.",
+      "Consistent access path from public pages into the app.",
+    ],
+    capabilitiesTitle: "Capabilities",
+    capabilities: [
+      "Personal pattern analysis",
+      "1:1 interaction analysis",
+      "Multi-person system analysis",
+      "Perspective comparison",
+      "Structured next-step guidance",
+    ],
+  },
+  useCases: {
+    kicker: "Use cases",
+    title: "Built for real moments, not abstract theory.",
+    intro: "Use Defrag when a conversation matters and you need clarity before your next move.",
+    cases: [
+      "Family conflict where care is present but communication is strained.",
+      "Partnership moments where both people feel misunderstood.",
+      "Team interactions where pressure shifts are hard to name.",
+      "Recurring dynamics where one pattern keeps replaying.",
+    ],
+  },
+  howItWorks: {
+    kicker: "How it works",
+    title: "From baseline to live field in one coherent rhythm.",
+    intro:
+      "The product flow is designed to reduce noise: establish context, read the interaction, then leave with one clear step.",
+    steps: [
+      {
+        label: "Baseline",
+        body: "Start with a short baseline so Defrag can read how pressure may land for you.",
+      },
+      {
+        label: "Field read",
+        body: "Open one live relationship moment and compare how each side may be reading it.",
+      },
+      {
+        label: "Next move",
+        body: "Leave with one concrete next step that protects dignity and lowers distortion.",
+      },
+    ],
+  },
+  productSystem: {
+    kicker: "Product system",
+    title: "One product language across public, studio, and workspace.",
+    intro:
+      "Defrag keeps the same tone and structure across touchpoints so people can stay oriented from preview to action.",
+    systemBullets: [
+      "Consistent CTA language across public pages.",
+      "Reusable marketing sections powered by one copy source.",
+      "No changes to billing behavior or workspace logic in this release.",
+    ],
+  },
+  about: {
+    eyebrow: "About Defrag",
+    title: "Defrag is a relational reasoning system for difficult interactions.",
+    description:
+      "We help people make high-pressure moments readable so better decisions are more possible.",
+    sections: [
+      {
+        title: "What Defrag does",
+        body: "Defrag turns a difficult interaction into structured relational analysis. It helps you understand what may be happening, how each side may be reading the moment, where pressure changed, and what move makes sense next.",
+      },
+      {
+        title: "How the system reads a moment",
+        body: "You bring the exchange, the people involved, and the context that matters. Defrag evaluates the interaction, compares perspective, reads pressure and timing, and returns a clearer view of the dynamic instead of only reflecting one narrator's story.",
+      },
+      {
+        title: "What the workspace returns",
+        body: "The workspace returns structured outputs such as what may be happening, what may be getting misread, where pressure changed, what pattern is forming, and what wording or next step is most likely to help.",
+      },
+      {
+        title: "Who it is built for",
+        body: "Defrag can be used for one person's recurring patterns, two-person interactions, family systems, team systems, and broader relational structures where tension and communication move across more than one participant.",
+      },
+      {
+        title: "What it is not",
+        body: "Defrag is not diagnosis, not generic advice, and not a replacement for professional support. It is a relational intelligence system built to make difficult interactions more readable and better decisions more possible.",
+      },
+    ],
+  },
+  faq: [
+    {
+      question: "Is Defrag therapy or diagnosis?",
+      answer:
+        "No. Defrag is a relational intelligence tool for clarity and next-step planning. It does not provide diagnosis or replace professional support.",
+    },
+    {
+      question: "Who is Defrag for?",
+      answer:
+        "People navigating difficult family, partnership, or team dynamics who want plain-language insight before they act.",
+    },
+    {
+      question: "What do I get after a field read?",
+      answer:
+        "You get a structured read of what may be happening, where pressure changed, and one grounded next move.",
+    },
+  ],
+  closingCta: {
+    kicker: "Start when you are ready",
+    title: "Open one relationship moment clearly.",
+    description: "Step into the studio flow and leave with a calmer next move.",
+    primaryCtaLabel: "Open Defrag",
+    primaryCtaHref: "/enter",
+    secondaryCtaLabel: "See how it works",
+    secondaryCtaHref: "/studio#how-it-works",
+  },
+};


### PR DESCRIPTION
### Motivation
- Centralize the public marketing surface into a single source-of-truth so approved website messaging and tone are consistently rendered. 
- Replace duplicated inline copy on the Studio route with reusable, typed sections to make content updates safe and maintain visual identity. 
- Normalize CTA language and anchors across public pages while preserving app, billing, and routing behavior.

### Description
- Added a canonical typed content module at `apps/web/src/content/marketingCopy.ts` that contains hero, output visibility, core value, product offering, capabilities, use cases, how-it-works steps, product system, about, FAQ, and closing CTA sections using arrays and TypeScript types. 
- Created reusable marketing components under `apps/web/src/components/marketing/`: `HeroSection.tsx`, `OutputVisibilitySection.tsx`, `CoreValueSection.tsx`, `UseCasesSection.tsx`, `HowItWorksSection.tsx`, `ProductSystemSection.tsx`, `FaqSection.tsx`, and `ClosingCtaSection.tsx`. 
- Refactored the Studio page to render from the reusable sections in `apps/web/src/app/studio/page.tsx` and updated the About page at `apps/web/src/app/about/page.tsx` to consume the canonical About narrative. 
- Normalized CTA language and targets (primary: `Open Defrag` → `/enter`, secondary: `See how it works` → `/studio#how-it-works`) and updated `apps/web/src/components/public-preview-cta.tsx` defaults accordingly.

### Testing
- Ran `pnpm typecheck`, which completed successfully and generated route types without type errors. 
- Attempted `pnpm --dir apps/web lint`, but the environment triggered an interactive ESLint setup prompt so lint could not complete non-interactively. 
- No typecheck errors were observed after the refactor; runtime checks and visual polish should be validated in a preview environment as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4069b12d48332976d3248df3d0f64)