### PR TITLE
Revamp studio marketing page: visual refresh, new ProofBlock, and content/schema updates

### DIFF
--- a/apps/web/src/app/studio/page.tsx
+++ b/apps/web/src/app/studio/page.tsx
@@ -1,12 +1,9 @@
 import Link from "next/link";
 import { ClosingCtaSection } from "../../components/marketing/ClosingCtaSection";
-import { CoreValueSection } from "../../components/marketing/CoreValueSection";
-import { FaqSection } from "../../components/marketing/FaqSection";
 import { HeroSection } from "../../components/marketing/HeroSection";
 import { HowItWorksSection } from "../../components/marketing/HowItWorksSection";
 import { OutputVisibilitySection } from "../../components/marketing/OutputVisibilitySection";
-import { ProductSystemSection } from "../../components/marketing/ProductSystemSection";
-import { UseCasesSection } from "../../components/marketing/UseCasesSection";
+import { ProofBlockSection } from "../../components/marketing/ProofBlockSection";
 import { marketingCopy } from "../../content/marketingCopy";
 
 export default function StudioHomePage() {
@@ -16,17 +13,36 @@ export default function StudioHomePage() {
         .mk-page {
           min-height: 100vh;
           background:
-            radial-gradient(1200px 680px at 78% -8%, rgba(235, 219, 190, 0.12), transparent 64%),
-            radial-gradient(920px 620px at 18% 20%, rgba(255, 255, 255, 0.05), transparent 68%),
-            linear-gradient(160deg, #080808 0%, #050505 42%, #090909 100%);
+            radial-gradient(1200px 680px at 78% -8%, rgba(234, 218, 181, 0.16), transparent 64%),
+            radial-gradient(940px 700px at -8% 18%, rgba(255, 255, 255, 0.06), transparent 70%),
+            linear-gradient(168deg, #060606 0%, #090909 48%, #050505 100%);
           color: #f5f2ec;
+          position: relative;
+          overflow: clip;
+        }
+        .mk-page::before {
+          content: "";
+          position: fixed;
+          inset: 0;
+          pointer-events: none;
+          background: repeating-linear-gradient(
+            120deg,
+            rgba(255, 255, 255, 0.018) 0,
+            rgba(255, 255, 255, 0.018) 1px,
+            transparent 1px,
+            transparent 6px
+          );
+          opacity: 0.24;
+          mix-blend-mode: soft-light;
         }
         .mk-shell {
-          width: min(1120px, 100%);
+          width: min(1160px, 100%);
           margin: 0 auto;
-          padding: 30px clamp(16px, 3.4vw, 40px) 96px;
+          padding: 28px clamp(16px, 3.8vw, 42px) 86px;
           display: grid;
-          gap: 56px;
+          gap: 48px;
+          position: relative;
+          z-index: 1;
         }
         .mk-header {
           display: flex;
@@ -50,9 +66,43 @@ export default function StudioHomePage() {
           text-transform: uppercase;
           border-bottom: 1px solid rgba(245, 242, 236, 0.24);
           padding: 6px 0;
+          transition: border-color 180ms ease, color 180ms ease;
         }
-        .mk-section { display: grid; gap: 14px; }
-        .mk-hero { padding-top: 10px; }
+        .mk-nav a:hover {
+          color: #fff;
+          border-color: rgba(245, 242, 236, 0.64);
+        }
+        .mk-section {
+          display: grid;
+          gap: 14px;
+          animation: mk-rise 700ms ease both;
+          animation-delay: calc(var(--mk-delay, 0) * 80ms);
+        }
+        .mk-hero {
+          --mk-delay: 0;
+          padding-top: 12px;
+          min-height: min(64vh, 660px);
+          align-content: center;
+          position: relative;
+          isolation: isolate;
+        }
+        .mk-hero::after {
+          content: "";
+          position: absolute;
+          right: -6%;
+          top: 12%;
+          width: min(510px, 52vw);
+          height: min(510px, 52vw);
+          border-radius: 28px;
+          border: 1px solid rgba(255, 255, 255, 0.14);
+          background:
+            radial-gradient(70% 60% at 62% 22%, rgba(237, 222, 187, 0.2), transparent 70%),
+            linear-gradient(150deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.01));
+          box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 40px 90px rgba(0, 0, 0, 0.48);
+          filter: blur(0.2px) saturate(112%);
+          z-index: -1;
+          animation: mk-drift 16s ease-in-out infinite;
+        }
         .mk-kicker {
           font-size: 10px;
           letter-spacing: 0.2em;
@@ -62,33 +112,36 @@ export default function StudioHomePage() {
         .mk-title {
           margin: 0;
           font-family: var(--font-display), serif;
-          font-size: clamp(2.7rem, 8vw, 6.4rem);
+          font-size: clamp(2.8rem, 8.8vw, 7.2rem);
           line-height: 0.9;
-          letter-spacing: -0.045em;
-          max-width: 13ch;
+          letter-spacing: -0.05em;
+          max-width: 11ch;
+          text-wrap: balance;
         }
         .mk-h2 {
           margin: 0;
           font-family: var(--font-display), serif;
-          font-size: clamp(1.7rem, 4.2vw, 3rem);
+          font-size: clamp(1.8rem, 4.2vw, 3.1rem);
           line-height: 0.95;
           letter-spacing: -0.03em;
+          text-wrap: balance;
         }
         .mk-h3 {
           margin: 0;
-          font-size: 1.1rem;
+          font-size: 1.08rem;
           letter-spacing: -0.01em;
           color: #fff;
+          font-weight: 500;
         }
         .mk-lead,
         .mk-body {
           margin: 0;
-          color: rgba(245, 242, 236, 0.72);
-          line-height: 1.8;
-          font-size: clamp(0.98rem, 1.35vw, 1.08rem);
-          max-width: 70ch;
+          color: rgba(245, 242, 236, 0.74);
+          line-height: 1.74;
+          font-size: clamp(0.96rem, 1.3vw, 1.05rem);
+          max-width: 58ch;
         }
-        .mk-actions { display: flex; gap: 12px; flex-wrap: wrap; padding-top: 4px; }
+        .mk-actions { display: flex; gap: 12px; flex-wrap: wrap; padding-top: 6px; }
         .mk-btn {
           display: inline-flex;
           align-items: center;
@@ -99,48 +152,50 @@ export default function StudioHomePage() {
           font-size: 12px;
           letter-spacing: 0.08em;
           text-transform: uppercase;
+          transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
         }
+        .mk-btn:hover { transform: translateY(-1px); }
         .mk-btn-primary {
-          background: linear-gradient(135deg, #faf6ee 0%, #e7d7b8 92%);
+          background: linear-gradient(135deg, #fbf7f0 0%, #e6d7b8 92%);
           color: #090909;
           font-weight: 600;
+          box-shadow: 0 10px 28px rgba(224, 201, 153, 0.26);
         }
         .mk-btn-secondary {
           color: #f5f2ec;
           border: 1px solid rgba(255, 255, 255, 0.26);
           background: rgba(255, 255, 255, 0.03);
         }
+        .mk-btn-secondary:hover { border-color: rgba(255, 255, 255, 0.42); }
         .mk-note {
           font-size: 11px;
           letter-spacing: 0.12em;
           text-transform: uppercase;
           color: rgba(245, 242, 236, 0.44);
         }
-        .mk-list {
-          margin: 0;
-          padding-left: 20px;
-          display: grid;
-          gap: 10px;
-          color: rgba(245, 242, 236, 0.72);
-          line-height: 1.75;
-        }
-        .mk-list-tight { gap: 6px; }
-        .mk-grid-2 {
-          display: grid;
-          grid-template-columns: minmax(0, 1fr) minmax(280px, 0.86fr);
-          gap: 24px;
-          align-items: start;
-        }
         .mk-card {
-          background: rgba(255, 255, 255, 0.03);
-          border: 1px solid rgba(255, 255, 255, 0.1);
+          background: linear-gradient(160deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+          border: 1px solid rgba(255, 255, 255, 0.13);
           border-radius: 20px;
           padding: 22px;
+          box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 18px 50px rgba(0, 0, 0, 0.35);
         }
-        .mk-steps { display: grid; gap: 12px; }
+        .mk-get-grid {
+          display: grid;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: 14px;
+        }
+        .mk-get-card { gap: 8px; display: grid; }
+        .mk-steps {
+          display: grid;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: 14px;
+        }
         .mk-step {
-          border-left: 1px solid rgba(255, 255, 255, 0.22);
-          padding-left: 16px;
+          border-radius: 18px;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          background: rgba(255, 255, 255, 0.02);
+          padding: 16px;
           display: grid;
           gap: 8px;
         }
@@ -150,15 +205,58 @@ export default function StudioHomePage() {
           text-transform: uppercase;
           color: rgba(245, 242, 236, 0.58);
         }
-        .mk-faq-grid {
+        .mk-proof-card {
+          border-radius: 22px;
+          border: 1px solid rgba(255, 255, 255, 0.14);
+          background:
+            radial-gradient(100% 140% at 84% -18%, rgba(230, 206, 160, 0.13), transparent 56%),
+            linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+          box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 24px 56px rgba(0, 0, 0, 0.4);
+          padding: clamp(20px, 4.5vw, 30px);
           display: grid;
-          gap: 12px;
-          grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: 18px;
         }
-        @media (max-width: 960px) {
-          .mk-grid-2,
-          .mk-faq-grid { grid-template-columns: 1fr; }
-          .mk-shell { gap: 44px; }
+        .mk-proof-line {
+          display: grid;
+          gap: 8px;
+          padding-bottom: 16px;
+          border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        .mk-proof-line:last-child {
+          padding-bottom: 0;
+          border-bottom: 0;
+        }
+        .mk-proof-label {
+          font-size: 10px;
+          letter-spacing: 0.18em;
+          text-transform: uppercase;
+          color: rgba(245, 242, 236, 0.56);
+        }
+        .mk-proof-reads {
+          display: grid;
+          gap: 6px;
+        }
+        @keyframes mk-rise {
+          from { opacity: 0; transform: translateY(10px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes mk-drift {
+          0%, 100% { transform: translateY(0px) translateX(0px); }
+          50% { transform: translateY(10px) translateX(-8px); }
+        }
+        @media (max-width: 980px) {
+          .mk-shell { gap: 40px; }
+          .mk-hero { min-height: auto; padding-top: 6px; }
+          .mk-hero::after {
+            width: min(400px, 78vw);
+            height: min(400px, 78vw);
+            right: -10%;
+            top: 26%;
+          }
+          .mk-get-grid,
+          .mk-steps {
+            grid-template-columns: 1fr;
+          }
         }
       `}</style>
       <div className="mk-shell">
@@ -173,11 +271,8 @@ export default function StudioHomePage() {
 
         <HeroSection copy={marketingCopy.hero} />
         <OutputVisibilitySection copy={marketingCopy.outputVisibility} />
-        <CoreValueSection copy={marketingCopy.coreValue} />
-        <UseCasesSection copy={marketingCopy.useCases} />
         <HowItWorksSection copy={marketingCopy.howItWorks} />
-        <ProductSystemSection copy={marketingCopy.productSystem} />
-        <FaqSection items={marketingCopy.faq} />
+        <ProofBlockSection copy={marketingCopy.proofBlock} />
         <ClosingCtaSection copy={marketingCopy.closingCta} />
       </div>
     </main>

--- a/apps/web/src/components/marketing/HowItWorksSection.tsx
+++ b/apps/web/src/components/marketing/HowItWorksSection.tsx
@@ -9,7 +9,6 @@ export function HowItWorksSection({ copy }: HowItWorksSectionProps) {
     <section id="how-it-works" className="mk-section">
       <div className="mk-kicker">{copy.kicker}</div>
       <h2 className="mk-h2">{copy.title}</h2>
-      <p className="mk-body">{copy.intro}</p>
       <div className="mk-steps">
         {copy.steps.map((step) => (
           <article key={step.label} className="mk-step">

--- a/apps/web/src/components/marketing/OutputVisibilitySection.tsx
+++ b/apps/web/src/components/marketing/OutputVisibilitySection.tsx
@@ -9,12 +9,14 @@ export function OutputVisibilitySection({ copy }: OutputVisibilitySectionProps) 
     <section className="mk-section">
       <div className="mk-kicker">{copy.kicker}</div>
       <h2 className="mk-h2">{copy.title}</h2>
-      <p className="mk-body">{copy.description}</p>
-      <ul className="mk-list">
-        {copy.bullets.map((item) => (
-          <li key={item}>{item}</li>
+      <div className="mk-get-grid">
+        {copy.items.map((item) => (
+          <article key={item.title} className="mk-card mk-get-card">
+            <h3 className="mk-h3">{item.title}</h3>
+            <p className="mk-body">{item.body}</p>
+          </article>
         ))}
-      </ul>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/components/marketing/ProofBlockSection.tsx
+++ b/apps/web/src/components/marketing/ProofBlockSection.tsx
@@ -1,0 +1,31 @@
+import type { ProofBlockCopy } from "../../content/marketingCopy";
+
+interface ProofBlockSectionProps {
+  copy: ProofBlockCopy;
+}
+
+export function ProofBlockSection({ copy }: ProofBlockSectionProps) {
+  return (
+    <section className="mk-section">
+      <div className="mk-kicker">{copy.kicker}</div>
+      <h2 className="mk-h2">{copy.title}</h2>
+      <article className="mk-proof-card">
+        <div className="mk-proof-line">
+          <div className="mk-proof-label">{copy.happenedLabel}</div>
+          <p className="mk-body">{copy.happenedBody}</p>
+        </div>
+        <div className="mk-proof-line">
+          <div className="mk-proof-label">{copy.readsLabel}</div>
+          <div className="mk-proof-reads">
+            <p className="mk-body">{copy.readsYou}</p>
+            <p className="mk-body">{copy.readsThem}</p>
+          </div>
+        </div>
+        <div className="mk-proof-line">
+          <div className="mk-proof-label">{copy.nextMoveLabel}</div>
+          <p className="mk-body">{copy.nextMoveBody}</p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/apps/web/src/content/marketingCopy.ts
+++ b/apps/web/src/content/marketingCopy.ts
@@ -12,8 +12,7 @@ export interface HeroCopy {
 export interface OutputVisibilityCopy {
   kicker: string;
   title: string;
-  description: string;
-  bullets: string[];
+  items: Array<{ title: string; body: string }>;
 }
 
 export interface CoreValueCopy {
@@ -37,8 +36,19 @@ export interface UseCasesCopy {
 export interface HowItWorksCopy {
   kicker: string;
   title: string;
-  intro: string;
   steps: Array<{ label: string; body: string }>;
+}
+
+export interface ProofBlockCopy {
+  kicker: string;
+  title: string;
+  happenedLabel: string;
+  happenedBody: string;
+  readsLabel: string;
+  readsYou: string;
+  readsThem: string;
+  nextMoveLabel: string;
+  nextMoveBody: string;
 }
 
 export interface ProductSystemCopy {
@@ -76,6 +86,7 @@ export interface MarketingCopy {
   coreValue: CoreValueCopy;
   useCases: UseCasesCopy;
   howItWorks: HowItWorksCopy;
+  proofBlock: ProofBlockCopy;
   productSystem: ProductSystemCopy;
   about: AboutCopy;
   faq: FaqItem[];
@@ -95,14 +106,21 @@ export const marketingCopy: MarketingCopy = {
     secondaryCtaHref: "/studio#how-it-works",
   },
   outputVisibility: {
-    kicker: "What Defrag actually gives you",
-    title: "Clear reads you can use right away.",
-    description:
-      "You get concrete guidance for one real moment, not generic advice.",
-    bullets: [
-      "What may have gone wrong in the interaction.",
-      "How each side may be reading the same moment differently.",
-      "A grounded next step in words you can actually use.",
+    kicker: "What you get",
+    title: "Three clear reads in one pass.",
+    items: [
+      {
+        title: "What went wrong",
+        body: "Pinpoint the turn without blame language.",
+      },
+      {
+        title: "How it landed",
+        body: "See your intent beside their likely read.",
+      },
+      {
+        title: "What to do next",
+        body: "Leave with wording you can actually send.",
+      },
     ],
   },
   coreValue: {
@@ -143,23 +161,32 @@ export const marketingCopy: MarketingCopy = {
   },
   howItWorks: {
     kicker: "How it works",
-    title: "Simple flow. Real-world decisions.",
-    intro:
-      "Defrag is designed to keep you oriented: bring the moment, review the read, then leave with one next move.",
+    title: "Simple flow. Better decisions.",
     steps: [
       {
         label: "Bring the moment",
-        body: "Share what happened in plain language, with enough context to understand the interaction.",
+        body: "Drop in the exchange that needs a steadier reply.",
       },
       {
-        label: "See both sides",
-        body: "Review how it likely landed for you and how it may have landed for them.",
+        label: "See the read",
+        body: "Review what likely happened for you and for them.",
       },
       {
-        label: "Choose your next move",
-        body: "Leave with wording and action guidance you can use in your next message or conversation.",
+        label: "Leave with a next move",
+        body: "Take one practical step you can use immediately.",
       },
     ],
+  },
+  proofBlock: {
+    kicker: "Interaction preview",
+    title: "A compact read that changes the next line.",
+    happenedLabel: "What happened",
+    happenedBody: "A conversation turned tense after a short reply.",
+    readsLabel: "What each side may be reading",
+    readsYou: "You were trying to stay steady.",
+    readsThem: "They may have felt distance.",
+    nextMoveLabel: "Next move",
+    nextMoveBody: "Lead with acknowledgment before explanation.",
   },
   productSystem: {
     kicker: "Product clarity",
@@ -218,9 +245,9 @@ export const marketingCopy: MarketingCopy = {
     },
   ],
   closingCta: {
-    kicker: "Ready when you are",
+    kicker: "Final step",
     title: "Bring one moment. Leave with a clearer next step.",
-    description: "Open Defrag before your next reply and move forward with steadier language.",
+    description: "Start with one exchange and leave with language you trust.",
     primaryCtaLabel: "Open Defrag",
     primaryCtaHref: "/enter",
     secondaryCtaLabel: "See how it works",


### PR DESCRIPTION
### Motivation
- Refresh the Studio marketing page visuals and layout to improve hierarchy, polish, and motion. 
- Replace several long-form sections with a compact proof/read block to surface the core product read more clearly. 
- Align component props and marketing copy shape with the new card-based output visibility and proof block UI.

### Description
- Overhauled page-level styles in `apps/web/src/app/studio/page.tsx` including updated gradients, overlay texture, spacing tweaks, animations, hero decoration, button/hover transitions, and several new utility classes like `.mk-get-grid`, `.mk-proof-card`, and `@keyframes mk-rise`/`mk-drift`.
- Replaced imports/usages of `CoreValueSection`, `UseCasesSection`, `ProductSystemSection`, and `FaqSection` with a new `ProofBlockSection` and updated the page component to render `ProofBlockSection` in the flow.
- Added `ProofBlockSection` component at `apps/web/src/components/marketing/ProofBlockSection.tsx` to render a three-line proof card with labels and reads.
- Modified `HowItWorksSection` to remove the intro paragraph and simplified step copy rendering.
- Reworked `OutputVisibilitySection` to render `copy.items` as a 3-column card grid (`.mk-get-grid`) and updated the component markup accordingly.
- Updated `apps/web/src/content/marketingCopy.ts` to change types and content: `OutputVisibilityCopy` now uses `items: Array<{title,body}>`, added `ProofBlockCopy` and `proofBlock` data, removed some intros and reworded multiple copy strings to match the new UI.

### Testing
- Ran TypeScript typecheck with `tsc --noEmit`, which completed successfully.
- Performed a Next.js production build with `next build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d442f9cef08332825005b0322e799f)