### PR TITLE
Mobile-first workspace layout and iPhone QA checkpoints

### DIFF
--- a/apps/web/src/app/workspace/final/page.tsx
+++ b/apps/web/src/app/workspace/final/page.tsx
@@ -68,6 +68,21 @@ type SessionResponse = {
 const INITIAL_MESSAGE =
   "I want to talk to my mom tonight, but I think we may end up missing each other again.";
 
+const SCENE_CONSTRAINTS: Record<"thread" | "field" | "guide", { mobileTopCopy: string; dominantIdea: string }> = {
+  thread: {
+    mobileTopCopy: "Start with one clear situation in plain language.",
+    dominantIdea: "Name the moment before trying to solve it.",
+  },
+  field: {
+    mobileTopCopy: "Read the live pattern before adding new details.",
+    dominantIdea: "See the pattern, pressure, and next small move.",
+  },
+  guide: {
+    mobileTopCopy: "Choose one support view, then return to the main thread.",
+    dominantIdea: "Use one guide at a time to stay emotionally clear.",
+  },
+};
+
 export default function FinalWorkspacePage() {
   const [message, setMessage] = useState(INITIAL_MESSAGE);
   const [session, setSession] = useState<SessionResponse | null>(null);
@@ -118,13 +133,13 @@ export default function FinalWorkspacePage() {
   return (
     <main style={{ minHeight: "100vh", background: "#050505", color: "#f5f2ec" }}>
       <style>{`
-        .fw-shell { display:grid; grid-template-columns: 420px minmax(0,1fr) 360px; min-height:100vh; }
-        .fw-col { border-right:1px solid rgba(255,255,255,0.07); }
-        .fw-col:last-child { border-right:none; }
+        .fw-shell { display:grid; grid-template-columns: 1fr; min-height:100vh; }
+        .fw-col { border-bottom:1px solid rgba(255,255,255,0.07); display:none; }
+        .fw-col.active { display:block; }
         .fw-top { display:flex; align-items:flex-end; justify-content:space-between; gap:14px; padding:20px 22px; border-bottom:1px solid rgba(255,255,255,0.07); }
         .fw-kicker { font-size:11px; letter-spacing:0.18em; text-transform:uppercase; color:rgba(245,242,236,0.42); }
         .fw-muted { color:rgba(245,242,236,0.62); }
-        .fw-title { font-size:32px; line-height:1.04; font-family:var(--font-display), serif; }
+        .fw-title { font-size:28px; line-height:1.08; font-family:var(--font-display), serif; text-wrap:balance; }
         .fw-chip { border:1px solid rgba(255,255,255,0.09); background:rgba(255,255,255,0.02); color:#f5f2ec; padding:9px 11px; font-size:12px; }
         .fw-chip.active { border-color:rgba(214,195,161,0.35); background:rgba(214,195,161,0.08); }
         .fw-thread { display:grid; gap:18px; padding:22px; }
@@ -152,22 +167,26 @@ export default function FinalWorkspacePage() {
         .fw-step { padding:12px 14px; border:1px solid rgba(255,255,255,0.08); background:rgba(255,255,255,0.02); line-height:1.62; }
         .fw-right { padding:22px; display:grid; gap:16px; align-content:start; }
         .fw-tooltip { padding:10px 12px; border:1px solid rgba(255,255,255,0.08); background:rgba(255,255,255,0.02); font-size:13px; color:rgba(245,242,236,0.74); }
-        .fw-tabbar { display:none; }
+        .fw-scene-focus { margin: 0 22px 0; padding: 12px 14px; border:1px solid rgba(214,195,161,0.2); background:rgba(214,195,161,0.06); display:grid; gap:6px; }
+        .fw-tabbar { position:sticky; bottom:0; display:grid; grid-template-columns:repeat(3,1fr); border-top:1px solid rgba(255,255,255,0.07); background:rgba(5,5,5,0.96); }
+        .fw-tabbtn { border:none; background:transparent; color:#f5f2ec; padding:16px 12px; min-height:52px; font-size:14px; }
+        .fw-tabbtn.active { background:rgba(214,195,161,0.08); }
         @keyframes fwSweep { from { left:-25%; } to { left:100%; } }
         @keyframes fwPulse { 0%, 100% { transform:scale(1); opacity:0.4; } 50% { transform:scale(1.05); opacity:0.72; } }
         @keyframes fwFloat { 0%, 100% { transform:translate(-50%, -50%) translateY(0px); } 50% { transform:translate(-50%, -50%) translateY(-4px); } }
-        @media (max-width: 1100px) {
-          .fw-shell { grid-template-columns: 1fr; }
-          .fw-col { border-right:none; border-bottom:1px solid rgba(255,255,255,0.07); display:none; }
-          .fw-col.active { display:block; }
-          .fw-tabbar { position:sticky; bottom:0; display:grid; grid-template-columns:repeat(3,1fr); border-top:1px solid rgba(255,255,255,0.07); background:rgba(5,5,5,0.96); }
-          .fw-tabbtn { border:none; background:transparent; color:#f5f2ec; padding:14px 12px; }
-          .fw-tabbtn.active { background:rgba(214,195,161,0.08); }
+        @media (min-width: 1101px) {
+          .fw-shell { grid-template-columns: 420px minmax(0,1fr) 360px; }
+          .fw-col { border-right:1px solid rgba(255,255,255,0.07); border-bottom:none; display:block; }
+          .fw-col:last-child { border-right:none; }
+          .fw-scene-focus { display:none; }
+          .fw-tabbar { display:none; }
+          .fw-title { font-size:32px; line-height:1.04; }
+          .fw-canvas::before { background:radial-gradient(circle at 50% 50%, rgba(214,195,161,0.10), transparent 34%), radial-gradient(circle at 20% 18%, rgba(255,255,255,0.06), transparent 30%), radial-gradient(circle at 82% 76%, rgba(255,255,255,0.04), transparent 28%); }
         }
       `}</style>
 
       <div className="fw-shell">
-        <section className={`fw-col ${tab === "thread" ? "active" : ""}`} style={{ display: tab === "thread" || typeof window === "undefined" ? undefined : undefined }}>
+        <section className={`fw-col ${tab === "thread" ? "active" : ""}`}>
           <div className="fw-top">
             <div style={{ display: "grid", gap: 6 }}>
               <div className="fw-kicker">Defrag workspace</div>
@@ -281,6 +300,11 @@ export default function FinalWorkspacePage() {
             <div className="fw-tooltip" title="What could help next means a small step that may make the situation easier to understand, not a guaranteed result.">What could help next</div>
           </div>
         </aside>
+      </div>
+
+      <div className="fw-scene-focus">
+        <div className="fw-kicker">{SCENE_CONSTRAINTS[tab].mobileTopCopy}</div>
+        <div style={{ lineHeight: 1.6 }}>{SCENE_CONSTRAINTS[tab].dominantIdea}</div>
       </div>
 
       <div className="fw-tabbar">

--- a/docs/qa/mobile-scene-checkpoints.md
+++ b/docs/qa/mobile-scene-checkpoints.md
@@ -1,0 +1,41 @@
+# Mobile Scene QA Checkpoints (Pre-Merge)
+
+## Purpose
+Guard the workspace experience so mobile readability and emotional legibility are validated before any merge.
+
+## Scene-Level Mobile-First Constraints
+Apply these checks to each scene (`Thread`, `Field`, `Guide`) at iPhone viewport sizes.
+
+1. **Tighter top copy**
+   - Header copy stays within two short lines.
+   - Intro copy avoids clause stacking and keeps one action verb per sentence.
+2. **Cleaner line breaks**
+   - No dense paragraph blocks above the first interaction.
+   - Primary explanatory text maintains comfortable scan rhythm (roughly 45–75 characters per line on iPhone width).
+3. **One dominant idea per viewport**
+   - The first visible card/message on each scene communicates one core intent only:
+     - Thread: name the moment.
+     - Field: read the pattern.
+     - Guide: choose one support view.
+4. **Thumb-friendly controls**
+   - Primary nav and action controls keep minimum 44px touch height.
+   - Adjacent interactive targets preserve enough spacing to avoid accidental taps.
+
+## Desktop Expansion Rule
+Desktop may only expand atmosphere and spacing. It must **not**:
+- alter information order,
+- introduce new required concepts,
+- add complexity that changes the mobile decision flow.
+
+Allowed desktop differences:
+- increased negative space,
+- asymmetrical composition,
+- richer visual atmosphere.
+
+## Required QA Checkpoint Passes (Before Merge)
+Run and record these checks on an iPhone-sized viewport (e.g., 390×844):
+
+- [ ] **Readability checkpoint**: All scene headers and top explanatory text are understandable at a glance without zooming.
+- [ ] **Emotional legibility checkpoint**: The user can identify the emotional intent of each scene in under 3 seconds (name moment / read pattern / choose guide).
+- [ ] **Touch checkpoint**: Bottom tabs and primary actions are comfortably tappable with one thumb.
+- [ ] **Order integrity checkpoint**: Desktop presents the same information order as mobile.

--- a/docs/qa/preview-mode-matrix.md
+++ b/docs/qa/preview-mode-matrix.md
@@ -19,3 +19,6 @@ When activated via cookie `__defrag_preview`:
 
 ## Launch Security
 This mechanism utilizes the absolute lowest-conflict perimeter. Because it intercepts Auth at the `server/auth.ts` level, no downstream API endpoints, components, or services had to be rewritten to handle "is this a preview". The system organically treats the QA process under maximum realism.
+
+## UX Gate Reference
+Before merging workspace UI updates, run the explicit mobile readability + emotional legibility checks in `docs/qa/mobile-scene-checkpoints.md`.


### PR DESCRIPTION
### Motivation
- Ensure the workspace is mobile-first so each scene presents a single, thumb-friendly idea and copy at iPhone viewports. 
- Keep desktop as an expansion layer (more space/atmosphere) without changing information order or adding complexity. 
- Add explicit QA gates to verify iPhone readability and emotional legibility before merging UI updates.

### Description
- Converted the final workspace to a mobile-first baseline by changing layout/CSS so scenes render as a single-column mobile flow and desktop styles are applied only in a `min-width` expansion query in `apps/web/src/app/workspace/final/page.tsx`.
- Added `SCENE_CONSTRAINTS` and a visible scene-focus panel to enforce tighter top copy and one dominant idea per viewport in `apps/web/src/app/workspace/final/page.tsx`.
- Improved mobile ergonomics by increasing tab button touch targets and tuning heading/wrapping behavior in `apps/web/src/app/workspace/final/page.tsx`.
- Added a new pre-merge QA checklist `docs/qa/mobile-scene-checkpoints.md` that defines tighter top copy, cleaner line breaks, one dominant idea per viewport, thumb-friendly controls, and the desktop expansion rule.
- Linked the new mobile QA gate into the existing preview QA documentation `docs/qa/preview-mode-matrix.md` so the checks are referenced in the QA hub.

### Testing
- Ran type checks with `pnpm typecheck` and the run completed successfully.
- No automated visual/browser screenshots were produced in this environment (manual device viewport checks are required as part of the new QA checklist).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d456fdd3808332a9fe985e0cc19708)